### PR TITLE
Remove readme's note about "pending code" in File Icons

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ For questions and support please use our [community chat](https://gitter.im/some
 
 ## Plugins
 
-* Atom: **[language-imba](http://github.com/somebee/language-imba)** can be installed through Atom Package Manager. File icon support is available via the File Icons package and the code pending in this **[issue](https://github.com/file-icons/atom/issues/664)** until integrated with the base package.
+* Atom: **[language-imba](http://github.com/somebee/language-imba)** can be installed through Atom Package Manager. File icon support is available via the [File Icons package](https://github.com/file-icons/atom).
 * Sublime Text: **[sublime-imba](http://github.com/somebee/sublime-imba)** can be installed through Sublime Package Manager.
 * VSCode: **[vscode-imba](http://github.com/somebee/vscode-imba)** can be installed through VSCode / Marketplace.
 


### PR DESCRIPTION
There appears to be some sort of mistake in the readme:

> File icon support is available via the File Icons package **and the code pending in this [issue](https://github.com/file-icons/atom/issues/664) until integrated with the base package.**

The linked issue was resolved ages ago; the icon's been part of the package since [v2.1.14](https://github.com/file-icons/atom/releases/tag/v2.1.14). I've just [finished updating](https://github.com/file-icons/atom/releases/tag/v2.1.29) the Imba icon again to accommodate its new branding.