### PR TITLE
fix crash in imbpack

### DIFF
--- a/bin/imbapack
+++ b/bin/imbapack
@@ -15,9 +15,8 @@ if(require.main !== module){
 
 	var webpack = require(path.join(require.main.filename, '..','..'));
 	var WebpackOptionsDefaulter = webpack.WebpackOptionsDefaulter;
-	var options = {};
 	var defaulter = new WebpackOptionsDefaulter;
-	defaulter.process(options);
+	var options = defaulter.process({});
 
 	var conf = {
 		module: {


### PR DESCRIPTION
```
TypeError: Cannot read property 'extensions' of undefined
    at Object.<anonymous> (/home/damjan/src/imba-router/node_modules/imba/bin/imbapack:27:32)
```

OptionsDefaulter.process in webpack doesn't mutate the input object, it returns a new one