### PR TITLE
Missing one carriage return on Webpack package

### DIFF
--- a/bin/imbapack
+++ b/bin/imbapack
@@ -171,7 +171,7 @@ cp.exec('npm bin', function(e,stdout,stderr){
 	cp.exec(checkWebpackCommand, function(e,stdout,stderr){
 		if (stdout.length == 0) {
 			process.stdout.write("Webpack need to be installed:\n");
-			process.stdout.write("\tnpm install -g webpack");
+			process.stdout.write("\tnpm install -g webpack\n");
 			process.exit(1);
 		}
 


### PR DESCRIPTION
Missing one carriage return on Webpack package warning when it has  not being installed by npm