### PR TITLE
test: fix run-chrome

### DIFF
--- a/test/run-chrome.imba
+++ b/test/run-chrome.imba
@@ -11,11 +11,11 @@ var consoleMapping = {
 }
 
 page.on 'console' do |msg|
-	var stringArgs = msg:args.map(do $1.toString)
-	var key = consoleMapping[msg:type] or msg:type
+	var stringArgs = msg:args().filter(Boolean).map do |x| x.toString
+	var key = consoleMapping[msg:type()] or msg:type()
 	console[key].apply(console, stringArgs)
 
-	if var m = msg:text.match(/(\d+) OK.* (\d+) FAILED.*(\d+) TOTAL/)
+	if var m = msg:text().match(/(\d+) OK.* (\d+) FAILED.*(\d+) TOTAL/)
 		var failed = Number(m[2])
 		process:exit(failed == 0 ? 0 : 1)
 


### PR DESCRIPTION
It was failing with losts of message like the following:

```
(node:55676) UnhandledPromiseRejectionWarning: TypeError: msg.args.map is not a function
    at Page.<anonymous> (/Users/ccscanf/src/github.com/imba/imba.git/test/run-chrome.imba:16:29)
    at emitOne (events.js:116:13)
    at Page.emit (events.js:211:7)
    at Page._addConsoleMessage (/Users/ccscanf/src/github.com/imba/imba.git/node_modules/puppeteer/lib/Page.js:628:10)
    at Page._onConsoleAPI (/Users/ccscanf/src/github.com/imba/imba.git/node_modules/puppeteer/lib/Page.js:550:10)
    at CDPSession.Page.client.on.event (/Users/ccscanf/src/github.com/imba/imba.git/node_modules/puppeteer/lib/Page.js:119:57)
    at emitOne (events.js:116:13)
    at CDPSession.emit (events.js:211:7)
    at CDPSession._onMessage (/Users/ccscanf/src/github.com/imba/imba.git/node_modules/puppeteer/lib/Connection.js:200:12)
    at Connection._onMessage (/Users/ccscanf/src/github.com/imba/imba.git/node_modules/puppeteer/lib/Connection.js:112:17)
(node:55676) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 297)
```