### PR TITLE
Handle data value can result in null

### DIFF
--- a/src/imba/dom/event-manager.imba
+++ b/src/imba/dom/event-manager.imba
@@ -153,7 +153,7 @@ class Imba.EventManager
 	###
 	def create type, target, data: null, source: null
 		var event = Imba.Event.wrap type: type, target: target
-		event.data = data if data
+		event.data = data if data != undefined
 		event.source = source if source
 		event
 

--- a/test/tags/events.imba
+++ b/test/tags/events.imba
@@ -85,11 +85,17 @@ tag Example
 				<div@bubbles :tap.mark(2)>
 				<div@self1 :tap.self.mark(2)> <b@inner1> "Label"
 				<div@self2 :tap.stop.self.mark(2)> <b@inner2> "Label"
-			
 				<div@redir :tap.stop.trigger(:redir)> "Label"
-				
+				<div@zero :tap.stop.zeroHandler> "Checking zero value"
+
+	def zeroHandler
+		trigger('zero', 0)
+
 	def onredir
 		emits.push('redir')
+
+	def onzero e
+		emits.push(e.data)
 				
 				
 	def tagAction
@@ -112,6 +118,7 @@ tag Example
 		eq @inner2.click, []
 		
 		eq @redir.click, ['redir']
+		eq @zero.click, [0]
 		return
 
 describe "Tags - Events" do


### PR DESCRIPTION
Fixed one bug where passing `0` to a trigger becomes `null`.

Closes: #203 (trigger data is null when supposed to be 0)