### PR TITLE
imbac: resolve the source and destination path in compile output

### DIFF
--- a/lib/cli/imbac.js
+++ b/lib/cli/imbac.js
@@ -287,6 +287,14 @@ CLI.prototype.compileFile = function (src){
 	var srcp = self.o().stdio ? src.filename : path.relative(process.cwd(),src.sourcePath);
 	var dstp = src.targetPath && path.relative(process.cwd(),src.targetPath);
 	
+	var srcpAbs = path.resolve(srcp);
+	var dstpAbs = path.resolve(dstp);
+	
+	if (srcp.indexOf("../") >= 0) {
+		srcp = srcpAbs;
+		dstp = dstpAbs;
+	};
+	
 	try {
 		out = compiler.compile(src.sourceBody,opts);
 	} catch (e) {

--- a/src/cli/imbac.imba
+++ b/src/cli/imbac.imba
@@ -246,8 +246,8 @@ class CLI
 		var out = {}
 		var t = Date.now
 		var at = Date.new.toTimeString.substr(0,8)
-		var srcp = o:stdio ? src:filename : path.relative(process.cwd,src:sourcePath)
-		var dstp = src:targetPath and path.relative(process.cwd,src:targetPath)
+		var srcp = path.resolve(o:stdio ? src:filename : path.relative(process.cwd,src:sourcePath))
+		var dstp = path.resolve(src:targetPath and path.relative(process.cwd,src:targetPath))
 
 		try
 			out = compiler.compile(src:sourceBody,opts)

--- a/src/cli/imbac.imba
+++ b/src/cli/imbac.imba
@@ -246,8 +246,15 @@ class CLI
 		var out = {}
 		var t = Date.now
 		var at = Date.new.toTimeString.substr(0,8)
-		var srcp = path.resolve(o:stdio ? src:filename : path.relative(process.cwd,src:sourcePath))
-		var dstp = path.resolve(src:targetPath and path.relative(process.cwd,src:targetPath))
+		var srcp = o:stdio ? src:filename : path.relative(process.cwd,src:sourcePath)
+		var dstp = src:targetPath and path.relative(process.cwd,src:targetPath)
+
+		var srcpAbs = path.resolve(srcp)
+		var dstpAbs = path.resolve(dstp)
+
+		if srcp.indexOf("../") >= 0
+			srcp = srcpAbs
+			dstp = dstpAbs
 
 		try
 			out = compiler.compile(src:sourceBody,opts)


### PR DESCRIPTION
This will change the `imbac` output after running it from

```
22:22:43 compile ../../../../../../tmp/x2.imba to ../../../../../../tmp/x2.js 14ms
```

To the following (looks nicer IMHO)

```
22:26:58 compile /tmp/x2.imba to /tmp/x2.js 14ms
```