### PR TITLE
tag: add error message when tags are used but unexported

### DIFF
--- a/src/imba/dom/tag.imba
+++ b/src/imba/dom/tag.imba
@@ -964,6 +964,9 @@ class Imba.Tags
 		tagtype:prototype?.optimizeTagStructure
 		
 	def findTagType type
+		if !type
+			throw("Expected a valid tag but got falsy type, did you forget to export it?")
+
 		let klass = self[type]
 		unless klass
 			if type.substr(0,4) == 'svg:'


### PR DESCRIPTION
The default error message for this is cryptic

```
[...]
imba/dom/tag.js:1207
    if (type.substr(0,4) == 'svg:') {

TypeError: Cannot read property 'substr' of undefined
[...]
```

Now it says

```
imba/dom/tag.js:1206
		throw ("Expected a valid tag but got falsy type, did you forget to export it?");
		^
Expected a valid tag but got falsy type, did you forget to export it?
[...]
```

Closes: #236 (Improve error message when importing private tag)