### PR TITLE
scripts/bootstrap: make the script much more verbose and robust

### DIFF
--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -6,7 +6,21 @@ var dist = path.resolve(__dirname,'..','dist');
 var tmp = path.resolve(__dirname,'..','build');
 var src = path.resolve(__dirname,'..','src');
 
+let showHelp = process.argv.filter(x => x.includes('--help') || x.includes('-h')).length > 0
 
+if (showHelp) {
+	console.log(`The Imba bootstraping script
+
+	USAGE
+		node ./scripts/bootstrap.sh
+
+	ENVIRONMENT VARIABLES
+		- VERBOSE=false - make the script be more silent set.
+    		- IGNORE_FS_ERRORS=false - don't show fs exceptions.
+    		- RESET=true - destroy the dist directory.
+`)
+	process.exit(0);
+}
 
 function pack(opts){
 	return new Promise(function(resolve,reject){
@@ -26,32 +40,67 @@ function pack(opts){
 		});
 	});
 }
+
+const inform = (arguments) => {
+	if (process.env.VERBOSE == false) {
+		return;
+	}
+	console.log('INFO', arguments);
+}
+
+const ensureExists = (thePath) => {
+	if (!fs.existsSync(thePath)) {
+		try{ 
+			fs.mkdirSync(thePath); 
+		} catch(e) {
+			console.error(e);
+
+			if (process.env.IGNORE_FS_ERRORS != false) {
+				process.exit(1);
+			}
+		}
+	}
+
+}
+
 async function main(){
-	if(fs.existsSync(dist)){ process.exit(0); };
-	try{ fs.mkdirSync(dist); } catch(e) {}
-	try{ fs.mkdirSync(tmp); } catch(e) {}
-	// make sure we generate the initial parser and all that
-	if(!fs.existsSync(dist) || true){
-		try{ fs.mkdirSync(dist); } catch(e) {}
+	inform('checking for the dist path', dist);
+	if(fs.existsSync(dist)) { 
+		inform('dist directory already present');
+		if (process.env.RESET != true) {
+			inform('aborting, to override run with environment RESET=true');
+			process.exit(0); 
+		} else {
+			console.log('removing the dist path', dist)
+			/* Note the below only works as of 12.10.0 */
+			// Reference: https://stackoverflow.com/questions/18052762/remove-directory-which-is-not-empty
+			fs.rmdirSync(dist, { recursive: true })
+		}
+	}
 
-		// compile grammar
-		var res = await pack({
-			entry: src + "/compiler/grammar.imba1",
-			mode: 'none',
-			output: {filename: './grammar.js', path: tmp}
-		});
+	inform('creating the dist directory', dist);
+	ensureExists(dist);
+	inform('creating the tmp directory', tmp);
+	ensureExists(tmp);
 
-		// Generate the parser
-		var parser = require(tmp + '/grammar.js').parser
-		fs.writeFileSync(tmp + "/parser.js", parser.generate());
+	inform('make sure we generate the initial parser and all that');
+	inform('compile grammar')
+	var res = await pack({
+		entry: src + "/compiler/grammar.imba1",
+		mode: 'none',
+		output: {filename: './grammar.js', path: tmp}
+	});
 
-		await pack({
-			entry: src + "/compiler/compiler.imba1",
-			output: {filename: './compiler.js'}
-		});
+	inform('Generate the parser');
+	var parser = require(tmp + '/grammar.js').parser
+	fs.writeFileSync(tmp + "/parser.js", parser.generate());
 
-		process.exit(0);
-	};
+	await pack({
+		entry: src + "/compiler/compiler.imba1",
+		output: {filename: './compiler.js'}
+	});
+
+	process.exit(0);
 }
 
 main();


### PR DESCRIPTION
The bootstrap script was flaky at best and would end up hanging for
hours in some cases. Without giving the user feedback it really looks
like it's maybe doing some serious setup work when in fact it's just
stuck.

The default behavior is every sane now IMHO, where exceptions are
visible but should not occur unless something is wrong on the
file system.

Just in case these changes cause issues I have added several
environment variables that can be used to override the new behavior.

- `VERBOSE=false` - make the script be more silent set.
- `IGNORE_FS_ERRORS=false` - don't show fs exceptions.
- `RESET=true` - destroy the dist directory.

Closes: #259 (v2: More feedback during bootstrap process)