### PR TITLE
add support for unmounting tags

### DIFF
--- a/src/imba/index.imba
+++ b/src/imba/index.imba
@@ -125,6 +125,9 @@ def imba.mount element, into
 	element.__schedule = yes
 	(into or document.body).appendChild(element)
 
+def imba.unmount element
+	const parent = element.parentElement
+	parent.removeChild(element)
 
 const CustomTagConstructors = {}
 


### PR DESCRIPTION
This way the user can cleanly remove tags that have been added for
example in the case of modals or context menu references.

This came out from discussions on how to currently handle those cases. This won't necessarily be the canonical way to do it but since we already expose mount, having an equivalent way of disposing of
tags make sense.