### PR TITLE
bin: don't bother running node with empty file

### DIFF
--- a/bin/imba
+++ b/bin/imba
@@ -93,6 +93,9 @@ function main(){
 	src = lookup(src);
 	src = path.resolve(process.cwd(),src);
 	var body = fs.readFileSync(src,'utf8');
+	if (!body) {
+		return body;
+	}
 	o.target = 'node';
 	o.sourcePath = o.filename = src;
 	return run(body,o);


### PR DESCRIPTION
Closes: #275 (CommonJS error message when running empty file)