### PR TITLE
Tweaking decorator syntax

### DIFF
--- a/src/compiler/grammar.imba1
+++ b/src/compiler/grammar.imba1
@@ -203,6 +203,7 @@ var grammar =
 
 	ImportSpecifier: [
 		o 'Identifier' do ImportSpecifier.new(A1)
+		o 'DecoratorIdentifier' do ImportSpecifier.new(A1)
 		o 'Identifier AS Identifier' do ImportSpecifier.new(A1, A3)
 		o 'DEFAULT' do ImportSpecifier.new(Literal.new(A1))
 		o 'DEFAULT AS Identifier' do ImportSpecifier.new(Literal.new(A1), A3)
@@ -249,6 +250,10 @@ var grammar =
 	Identifier: [
 		o 'IDENTIFIER' do Identifier.new A1
 	]
+	
+	DecoratorIdentifier: [
+		o 'DECORATOR' do DecoratorIdentifier.new A1
+	]
 
 	Key: [
 		o 'KEY' do Identifier.new A1
@@ -268,9 +273,9 @@ var grammar =
 	]
 	
 	Decorator: [
-		o 'DECORATOR' do Decorator.new A1 # kinda hacky, should be defined as something else
-		o 'DECORATOR ( )' do Decorator.new(A1)
-		o 'DECORATOR ( ArgList )' do Decorator.new(A1).set(params: A3)
+		o 'DecoratorIdentifier' do Decorator.new A1 # kinda hacky, should be defined as something else
+		o 'DecoratorIdentifier ( )' do Decorator.new(A1)
+		o 'DecoratorIdentifier ( ArgList )' do Decorator.new(A1).set(params: A3)
 	]
 
 	Decorators: [
@@ -544,6 +549,7 @@ var grammar =
 
 	MethodIdentifier: [
 		o 'Identifier'
+		o 'DecoratorIdentifier'
 		o '[ Expression ]' do InterpolatedIdentifier.new(A2)
 	]
 

--- a/src/compiler/nodes.imba1
+++ b/src/compiler/nodes.imba1
@@ -4985,6 +4985,14 @@ export class Identifier < Node
 		stack.registerSemanticToken(@value,@variable)
 		return self
 
+export class DecoratorIdentifier < Identifier
+	
+	def symbol
+		"decorator${@value.slice(1)}"
+		
+	def toString
+		symbol
+
 export class Private < Identifier
 
 	def symbol
@@ -5034,11 +5042,11 @@ export class Ivar < Identifier
 export class Decorator < ValueNode
 
 	def name
-		@name ||= @value.slice(1)
+		@name ||= @value.js
 	
 	def visit
-		
 		@variable = scope__.lookup(name)
+		@value.@variable ||= @variable
 
 		@call.traverse if @call
 		if option(:params)
@@ -5052,21 +5060,9 @@ export class Decorator < ValueNode
 	def c 
 		# should return other places as well...
 		return if STACK.current isa ClassBody
-		# name must be a 
-		let out
-		
-		
-		if @variable
-			out = @variable.c
-		else
-			let name = 'decorator$' + AST.sym(name)
-			let op = OP(
-				'||',
-				OP('.',OP('.',THIS,'prototype'),name),
-				OP('.',LIT('imba'),name)
-			)
-			out = '(' + op.c + ')'
 
+		let out = @value.c
+		
 		if @params
 			out += ".bind([{@params.c(expression: yes)}])"
 		else

--- a/test/apps/decorators/multiple.imba
+++ b/test/apps/decorators/multiple.imba
@@ -1,6 +1,6 @@
 
 
-def bench target,key,desc
+def @bench target,key,desc
 	let prev = desc.value
 	desc.value = do
 		let t = Date.now!
@@ -10,16 +10,18 @@ def bench target,key,desc
 		return res
 	return
 
-class Item
-	def decorator$log target,key,desc
+def @log target,key,desc
 		let prefix = this[0] or 'nopre'
 		let prev = desc.value
 		desc.value = do
 			console.log "call {prefix} {key}"
 			return prev.apply(this,arguments)
 		return
+		
+class Item
 	
-	@log @log('hello') @bench
+	
+	@log('hello') @bench
 	def setup
 		let i = 0
 		let sum = 0

--- a/test/apps/issues/278.imba
+++ b/test/apps/issues/278.imba
@@ -20,9 +20,9 @@ tag app-root
 			# second click on 'FOO' renders app-foo and app-bar
 			<div :click.change('foo')> "FOO"
 			<div :click.change('bar')> "BAR"
-			if @view == 'foo'
+			if view == 'foo'
 				<app-foo>
-			elif @view == 'bar'
+			elif view == 'bar'
 				<app-bar>
 			else
 				<app-not-found>

--- a/test/apps/syntax/decorators.imba
+++ b/test/apps/syntax/decorators.imba
@@ -1,16 +1,16 @@
 
-def log target,key,desc
+def @log target,key,desc
 	let prev = desc.value
 	desc.value = do
 		console.info "call {key}"
 		return prev.apply(this,arguments)
 	return
 
-def readonly target,key,desc
+def @readonly target,key,desc
 	desc.writable = false
 	return desc
 
-def debounce target,key,descriptor
+def @debounce target,key,descriptor
 	let wait = this[0] or 100
 	const sym = Symbol('debounces')
 	const callback = descriptor.value
@@ -27,7 +27,7 @@ def debounce target,key,descriptor
 
 	return descriptor
 
-def track target,key,desc
+def @track target,key,desc
 	let getter = desc.get
 	let setter = desc.set
 	if getter isa Function
@@ -41,7 +41,7 @@ def track target,key,desc
 	# desc.writable = false
 	return desc
 
-def watch target,key,desc
+def @watch target,key,desc
 
 	let meth = this[0] or (key + 'DidSet')
 	let setter = desc.set


### PR DESCRIPTION
Changed how decorators are defined. You can now export and import decorators like everything else. Any method starting with `@` is treated as a decorator.

```imba
# decorators.imba
export def @log target, key, descriptor
	let value = descriptor.value
	descriptor.value = do
		console.log("called {key}")
		return value.apply(this,arguments)
	return descriptor
```

```imba
# app.imba
import { @log  } from './decorators'

tag user-item
	@log def render
		<self> ...

```

I'm still trying to come up with a good way to allow passing options to decorators without having to think about whether something is a decorator or a decorator factory (see https://www.typescriptlang.org/docs/handbook/decorators.html). It is subject to change, but right now, any arguments you pass into to decorators will be exposed on self/this in the decorator method.

```imba
# app.imba
def @readonly target, key, descriptor
	let bool = this[0] isa Boolean ? this[0] : yes
	descriptor.readonly = bool
	return descriptor

tag user-item
	@readonly def one
		self

	@readonly(no) def two
		self
```

It isn't perfect, but with some tweaking I think it will be much better than differentiating between decorators and their factories. Also contemplating some shorthand syntax for adding modifiers to decorators - like the event syntax. So `@decor.async.something` would call the `@decor` decorator, but the flags `{async: true, something: true}` would be accessible within the decor context.

It works very well with vscode autocompletions and auto-importing:
![2020-04-04 12 06 32](https://user-images.githubusercontent.com/8467/78424323-125fc300-766d-11ea-9596-4a5466151da1.gif)
