### PR TITLE
Simplified class fields

### DIFF
--- a/src/compiler/grammar.imba1
+++ b/src/compiler/grammar.imba1
@@ -565,6 +565,7 @@ var grammar =
 	AssignObj: [
 		o 'MethodDeclaration' do A1.set(inObject: yes)
 		o 'ObjAssignable' do ObjAttr.new(A1)
+		o '...' do ObjRestAttr.new(A1)
 		o 'ObjAssignable : Expression' do ObjAttr.new(A1, A3)
 		o 'ObjAssignable : INDENT Expression Outdent' do ObjAttr.new(A1, A4.indented(A3,A5))
 		o 'SimpleObjAssignable = Expression' do ObjAttr.new(A1, null, A3)
@@ -709,6 +710,7 @@ var grammar =
 		o 'ParamVar = ParamValue' do Param.new(A1.value,A3).set(datatype: A1.option(:datatype))
 		o 'Object = ParamValue' do Param.new(A1,A3)
 		o 'Array = ParamValue' do Param.new(A1,A3)
+		o '...' do RestParam.new(A1)
 		# OptionalParam.new A1, A3, A2
 	]
 
@@ -864,17 +866,26 @@ var grammar =
 	]
 
 	ClassStart: [
-		o 'CLASS SimpleAssignable' do ClassDeclaration.new(A2, null, []).set(keyword: A1)
-		o 'CLASS SimpleAssignable ClassBody' do ClassDeclaration.new(A2, null, A3).set(keyword: A1)
+		o 'CLASS Identifier ClassConstructorParams ClassBody' do ClassDeclaration.new(A2, null, A4).set(keyword: A1,params: A3)
+		o 'CLASS Identifier ClassConstructorParams' do ClassDeclaration.new(A2, null, []).set(keyword: A1,params: A3)
+		o 'CLASS Identifier ClassBody' do ClassDeclaration.new(A2, null, A3).set(keyword: A1)
+		o 'CLASS Identifier' do ClassDeclaration.new(A2, null, []).set(keyword: A1)
+		
 		o 'CLASS ClassBody' do ClassDeclaration.new(null, null, A2).set(keyword: A1)
-		o 'CLASS SimpleAssignable COMPARE Expression' do ClassDeclaration.new(A2, A4, []).set(keyword: A1)
-		o 'CLASS SimpleAssignable COMPARE Expression ClassBody' do ClassDeclaration.new(A2, A4, A5).set(keyword: A1)
+		o 'CLASS Identifier ClassConstructorParams COMPARE Expression ClassBody' do ClassDeclaration.new(A2, A5, A6).set(keyword: A1, params: A3)
+		o 'CLASS Identifier ClassConstructorParams COMPARE Expression' do ClassDeclaration.new(A2, A6, []).set(keyword: A1, params: A3)
+		o 'CLASS Identifier COMPARE Expression' do ClassDeclaration.new(A2, A4, []).set(keyword: A1)
+		o 'CLASS Identifier COMPARE Expression ClassBody' do ClassDeclaration.new(A2, A4, A5).set(keyword: A1)
 		o 'CLASS COMPARE Expression ClassBody' do ClassDeclaration.new(null, A3, A4).set(keyword: A1)
+	]
+	
+	ClassConstructorParams: [
+		o 'CALL_START ParamList CALL_END' do A2
 	]
 
 	ClassIdentifier: [
-		o '' do null
-		o 'SimpleAssignable'
+		# o '' do null
+		o 'IDENTIFIER' do Identifier.new(A1)
 	]
 
 	ClassBody: [

--- a/src/compiler/lexer.imba1
+++ b/src/compiler/lexer.imba1
@@ -843,7 +843,7 @@ export class Lexer
 
 	def isKeyword id
 		if @lastTyp == 'ATTR' or @lastTyp == 'PROP' or @lastTyp == 'DEF'
-			return false 
+			return false
 			
 		if id == 'get' or id == 'set'
 			if let m = @chunk.match(/^[gs]et ([\$\w\-]+)/) # ( (do)|\n(\t+))
@@ -872,7 +872,7 @@ export class Lexer
 			if (@lastTyp in ['='])
 				return true
 
-		if (id == 'attr' or id == 'prop' or id == 'get' or id == 'set' or id == 'lazy' or id == 'css')
+		if (id == 'attr' or id == 'prop' or id == 'get' or id == 'set' or id == 'lazy' or id == 'css' or id == 'constructor')
 			var scop = getScope
 			var incls = scop == 'CLASS' or scop == 'TAG' or scop == 'STRUCT'
 
@@ -883,6 +883,9 @@ export class Lexer
 			# 	return true
 
 			if id == 'lazy'
+				return incls and @lastTyp in ['INDENT','TERMINATOR','DECORATOR']
+				
+			if id == 'constructor'
 				return incls and @lastTyp in ['INDENT','TERMINATOR','DECORATOR']
 
 			return true if incls
@@ -1009,6 +1012,11 @@ export class Lexer
 			# what we want is a context-stack
 			elif (typ == 'DEF' or typ == 'GET' or typ == 'SET')
 				typ = 'DEF'
+				openDef
+				
+			elif (typ == 'CONSTRUCTOR')
+				token('DEF','',0)
+				typ = 'IDENTIFIER'
 				openDef
 
 			elif typ == 'DO'

--- a/src/compiler/nodes.imba1
+++ b/src/compiler/nodes.imba1
@@ -1611,9 +1611,17 @@ export class Block < ListNode
 			return super(o,nodes: ast)
 
 		var str = ""
-
+		let empty = no
 		for v in ast
-			str += cpart(v)
+			let vs = cpart(v)
+			# FIXME windows?
+			if vs[0] == '\n' and (/^\n+$/).test(vs)
+				continue if empty
+				empty = yes
+			elif vs
+				empty = no
+			# console.log 'add item?',JSON.stringify(vs)
+			str += vs
 
 		# now add the head items as well
 		if @head and @head:length > 0
@@ -1704,12 +1712,12 @@ export class ClassField < Node
 		@decorators = up?.collectDecorators
 		@name.traverse if @name and @name:traverse
 
-		if value and STACK.tsc
+		if value and (STACK.tsc or true)
 			value.@scope = MethodScope.new(value)
 			value.@scope.@parent = scope__
 			value.traverse # if @value # dont traverse yet
 
-		if !STACK.tsc and !option(:raw)
+		if !STACK.tsc and !option(:raw) and @decorators
 			@storage = scope__.root.declare(null,LIT('new WeakMap()'))
 
 		# traverse value with a different scope
@@ -1729,7 +1737,13 @@ export class ClassField < Node
 		!@decorators and (!@value or @value.isPrimitive)
 
 	def isLazy
-		yes
+		no
+		
+	def hasStaticInits
+		isStatic or @decorators
+		
+	def hasConstructorInits
+		!isStatic
 
 	def isStatic
 		option(:static)
@@ -1753,20 +1767,42 @@ export class ClassField < Node
 				out += " = {value.c}" if value
 				if let typ = TYP(@name,'jsdoc')
 					out = "{typ}\n{out}"
-			else
+			elif false
 				out = "{prefix}set {name}{setter.c(keyword: '')}\n{prefix}get {name}{getter.c(keyword: '')}"
 
 		elif up isa ClassInitBlock and !STACK.tsc
-			if !isLazy and isPlain and value
-				out = util.setField(target,name,value).c + ';\n'
-			# else
-			# 	let obj = Obj.wrap(enumerable: false, writable: true, value: LIT('undefined'))
-			# 	out = util.initField(target,storageKey,obj).c + ';\n'
+			if !isLazy and isStatic # and isPlain 
+				# out = util.setField(target,name,value).c + ';\n'
+				out = OP('=',OP('.',THIS,name),value or UNDEFINED).c + ';\n'
 
 		elif up isa InstanceInitBlock and !isStatic and !isLazy and !STACK.tsc
-			if value
-				# out = util.setField(THIS,name,value).c + ';\n'
-				out = OP('.',THIS,name).c + ';\n'
+			let ctor = up.option(:ctor)
+			let opts = up.option(:opts)
+			let val = value or UNDEFINED
+			
+			let paramIndex = option(:paramIndex)
+			let restIndex = option(:restIndex)
+			let access
+			
+			if paramIndex != undefined
+				let name = option(:paramName)
+				access = ctor.@params.at(paramIndex,yes,name)
+				if value
+					val = If.ternary(OP('!==',access,UNDEFINED),access,val)
+				else
+					val = access
+
+			elif restIndex != undefined
+				let rest = ctor.@params.at(restIndex,yes,'_fields')
+				access = OP('.',rest,name)
+
+				if value
+					access.cache(reuse: yes, name: 'v')
+					val = If.ternary(OP('&&',rest,OP('!==',access,UNDEFINED)),access,val)
+				else
+					val = If.ternary(rest,access,UNDEFINED)
+				
+			out = OP('=',OP('.',THIS,name),val).c + ';\n'
 
 		return out
 
@@ -2114,6 +2150,8 @@ export class Param < Node
 			name: name
 			defaults: defaults
 		}
+		
+export class RestParam < Param
 
 export class BlockParam < Param
 
@@ -2721,7 +2759,8 @@ export class ClassDeclaration < Code
 		no
 
 	def staticInit
-		@staticInit ||= addMethod('init$',[],@superclass ? 'super.inherited instanceof Function && super.inherited(this)' : 'this').set(static: yes)
+		# @superclass ? 'super.inherited instanceof Function && super.inherited(this)' : 'this'
+		@staticInit ||= addMethod('init$',[],'this').set(static: yes)
 
 	def instanceInit
 		@instanceInit ||= addMethod('init$',[],isTag ? 'super.init$()' : '')
@@ -2746,8 +2785,53 @@ export class ClassDeclaration < Code
 		ROOT.entities.add(namepath,self)
 		scope.visit
 
-		if @superclass and !option(:extension) and !STACK.tsc
-			staticInit
+		# if @superclass and !option(:extension) and !STACK.tsc
+		#	staticInit
+		
+		var fields = []
+		var signature = []
+		var params = []
+		var declaredFields = {}
+		var restIndex = undefined
+		
+		
+		for node in body when node isa ClassField
+			if !node.isStatic
+				let name = String(node.name)
+				declaredFields[name] = node
+		
+		if option(:params)
+			# find the rest param
+			let add = []
+			for param,index in option(:params) # .reverse
+				
+				if param isa RestParam
+					restIndex = index
+					continue
+					
+				let name = String(param.name)
+				let field = declaredFields[name]
+				let dtyp = param.option(:datatype)
+
+				if !field
+					field = fields[name] = ClassField.new(param.name).set(
+						datatype: dtyp
+						value: param.defaults
+					)
+					# field.set(param: param)
+					add.push(field)
+					params.push(param)
+				else
+					if dtyp and !field.datatype
+						field.set(datatype: dtyp)
+					if param.defaults and !field.value
+						field.set(value: param.defaults)
+				
+				if field
+					field.set(paramIndex: index, paramName: name)
+
+			for item in add.reverse
+				body.unshift(item)
 
 		body.traverse
 
@@ -2759,8 +2843,13 @@ export class ClassDeclaration < Code
 		var ctor = body.option(:ctor)
 
 		for node in body when node isa ClassField
-			staticInits.add(node)
-			inits.add(node)
+			if node.hasStaticInits
+				staticInits.add(node)
+			if node.hasConstructorInits
+				inits.add(node)
+				
+			if !node.isStatic and restIndex != null
+				node.set(restIndex: restIndex)
 
 		for node,i in body
 			if node.@decorators
@@ -2778,9 +2867,12 @@ export class ClassDeclaration < Code
 			elif ctor
 				let after = ctor.option(:injectInitAfter)
 				# inject before/after super or something
+				inits.set(ctor: ctor)
 				ctor.inject(inits,after ? {after: after} : 0)
 			else
-				ctor = addMethod('constructor',[],superclass ? 'super(...arguments)' : 'this')
+				ctor = addMethod('constructor',[],superclass ? 'super(...arguments)' : '')
+				# inits.set(opts: ctor.@params.at(0,yes))
+				inits.set(ctor: ctor)
 				ctor.inject(BR)
 				ctor.inject(inits)
 
@@ -3947,6 +4039,8 @@ export class ObjAttr < Node
 	def isPrimitive deep
 		!@value or @value.isPrimitive(deep)
 
+
+export class ObjRestAttr < ObjAttr
 
 export class ArgsReference < Node
 
@@ -9715,6 +9809,7 @@ export class Scope
 	# we only need a temporary thing with defaults -- that is all
 	# change these values, no?
 	def temporary decl, o = {}, name = null
+		name ||= o:name
 		if name and o:reuse and @vars["_temp_{name}"]
 			return @vars["_temp_{name}"]
 

--- a/src/compiler/nodes.imba1
+++ b/src/compiler/nodes.imba1
@@ -1712,18 +1712,14 @@ export class ClassField < Node
 		@decorators = up?.collectDecorators
 		@name.traverse if @name and @name:traverse
 
-		if value and (STACK.tsc or true)
-			value.@scope = MethodScope.new(value)
+		if value
+			value.@scope = @vscope = FieldScope.new(value)
 			value.@scope.@parent = scope__
-			value.traverse # if @value # dont traverse yet
+			value.traverse
 
-		if !STACK.tsc and !option(:raw) and @decorators
-			@storage = scope__.root.declare(null,LIT('new WeakMap()'))
-
-		# traverse value with a different scope
 		self
-		
-		
+	
+
 	def value
 		option(:value)
 
@@ -1753,11 +1749,10 @@ export class ClassField < Node
 
 	def c
 		return if option(:struct)
-
+		
 		let up = STACK.current
 		let out
 		if up isa ClassBody
-			
 			# return if isPlain
 			let prefix = isStatic ? "{M('static',option(:static))} " : ''
 			let name = name isa IdentifierExpression ? name.asObjectKey : name.c
@@ -1767,42 +1762,51 @@ export class ClassField < Node
 				out += " = {value.c}" if value
 				if let typ = TYP(@name,'jsdoc')
 					out = "{typ}\n{out}"
-			elif false
+			elif self isa ClassAttribute
 				out = "{prefix}set {name}{setter.c(keyword: '')}\n{prefix}get {name}{getter.c(keyword: '')}"
-
-		elif up isa ClassInitBlock and !STACK.tsc
-			if !isLazy and isStatic # and isPlain 
-				# out = util.setField(target,name,value).c + ';\n'
+			
+		elif !STACK.tsc
+			if isStatic and up isa ClassInitBlock
+				if @vscope
+					if let fn = STACK.up(Func)
+						@vscope.mergeScopeInto(fn.@scope)
 				out = OP('=',OP('.',THIS,name),value or UNDEFINED).c + ';\n'
 
-		elif up isa InstanceInitBlock and !isStatic and !isLazy and !STACK.tsc
-			let ctor = up.option(:ctor)
-			let opts = up.option(:opts)
-			let val = value or UNDEFINED
-			
-			let paramIndex = option(:paramIndex)
-			let restIndex = option(:restIndex)
-			let access
-			
-			if paramIndex != undefined
-				let name = option(:paramName)
-				access = ctor.@params.at(paramIndex,yes,name)
-				if value
-					val = If.ternary(OP('!==',access,UNDEFINED),access,val)
-				else
-					val = access
+			elif !isStatic and up isa InstanceInitBlock
+				if @vscope
+					if let fn = STACK.up(Func)
+						@vscope.mergeScopeInto(fn.@scope)
 
-			elif restIndex != undefined
-				let rest = ctor.@params.at(restIndex,yes,'_fields')
-				access = OP('.',rest,name)
-
-				if value
-					access.cache(reuse: yes, name: 'v')
-					val = If.ternary(OP('&&',rest,OP('!==',access,UNDEFINED)),access,val)
-				else
-					val = If.ternary(rest,access,UNDEFINED)
+				let ctor = up.option(:ctor)
+				let opts = up.option(:opts)
+				let val = value or UNDEFINED
 				
-			out = OP('=',OP('.',THIS,name),val).c + ';\n'
+				let paramIndex = option(:paramIndex)
+				let restIndex = option(:restIndex)
+				let access
+				
+				if paramIndex != undefined
+					let name = option(:paramName)
+					access = ctor.@params.at(paramIndex,yes,name)
+					if value
+						val = If.ternary(OP('!==',access,UNDEFINED),access,val)
+					else
+						val = access
+
+				elif restIndex != undefined
+					let rest = ctor.@params.at(restIndex,yes,'_fields')
+					access = OP('.',rest,name)
+
+					if value
+						access.cache(reuse: yes, name: 'v')
+						val = If.ternary(OP('&&',rest,OP('!==',access,UNDEFINED)),access,val)
+					else
+						val = If.ternary(rest,access,UNDEFINED)
+				
+				if self isa ClassAttribute and !value
+					return
+
+				out = OP('=',OP('.',THIS,name),val).c + ';\n'
 
 		return out
 
@@ -2763,7 +2767,7 @@ export class ClassDeclaration < Code
 		@staticInit ||= addMethod('init$',[],'this').set(static: yes)
 
 	def instanceInit
-		@instanceInit ||= addMethod('init$',[],isTag ? 'super.init$()' : '')
+		@instanceInit ||= addMethod('init$',[],isTag ? 'super.init$()' : '').set(noreturn: yes)
 
 	def visit
 		# replace with some advanced lookup?
@@ -2803,7 +2807,7 @@ export class ClassDeclaration < Code
 		if option(:params)
 			# find the rest param
 			let add = []
-			for param,index in option(:params) # .reverse
+			for param,index in option(:params)
 				
 				if param isa RestParam
 					restIndex = index
@@ -2862,6 +2866,7 @@ export class ClassDeclaration < Code
 		if !inits.isEmpty
 			if isTag
 				ctor = instanceInit
+				inits.set(ctor: ctor)
 				ctor.inject(inits)
 
 			elif ctor
@@ -2871,7 +2876,6 @@ export class ClassDeclaration < Code
 				ctor.inject(inits,after ? {after: after} : 0)
 			else
 				ctor = addMethod('constructor',[],superclass ? 'super(...arguments)' : '')
-				# inits.set(opts: ctor.@params.at(0,yes))
 				inits.set(ctor: ctor)
 				ctor.inject(BR)
 				ctor.inject(inits)
@@ -10160,6 +10164,22 @@ export class MethodScope < Scope
 
 	def setup
 		@selfless = no
+
+export class FieldScope < Scope
+	
+	def setup
+		@selfless = no
+		
+	def mergeScopeInto other
+		for own k,v of @varmap
+			continue if k == 'self'
+			v.resolve(other,yes)
+			other.declare(v)
+		
+		if @context and @context.@reference
+			@context.@reference = other.context.reference
+		yes
+
 
 export class LambdaScope < Scope
 

--- a/test/apps/decorators/multiple.imba
+++ b/test/apps/decorators/multiple.imba
@@ -18,8 +18,10 @@ def @log target,key,desc
 			return prev.apply(this,arguments)
 		return
 		
+
+
+		
 class Item
-	
 	
 	@log('hello') @bench
 	def setup

--- a/test/apps/events/functions.imba
+++ b/test/apps/events/functions.imba
@@ -7,7 +7,7 @@ tag app-root
 	prop value = null
 
 	prop model = {
-		update: do |val| counter = val
+		update: do(val) counter = val
 	}
 	
 	def hello

--- a/test/apps/rendering/attributes.imba
+++ b/test/apps/rendering/attributes.imba
@@ -1,0 +1,19 @@
+test 'attributes without value' do
+	let el = <button disabled>
+	ok el.hasAttribute('disabled')
+
+tag A
+	attr someattr
+	attr preattr = 'hello'
+
+test 'attr declaration' do
+	let el = <A someattr=1>
+	ok el.hasAttribute('someattr')
+	
+test 'attr default' do
+	let el = <A>
+	eq el.getAttribute('preattr'), 'hello'
+	
+test 'attr default override' do
+	let el = <A preattr='world'>
+	eq el.getAttribute('preattr'), 'world'

--- a/test/apps/syntax/class-fields.imba
+++ b/test/apps/syntax/class-fields.imba
@@ -63,16 +63,19 @@ class A
 	prop desc = new Dyn('d1')
 	prop desc2 = new Dyn(desc.ref + '2')
 
+test do
+	let item = new A
+	eq $1.log, ['v1','o1','d1','d12']
+	
 class B < A
 	prop number = 2
 	prop options = new Dyn('o2')
 	
 test do
 	let item = new B
-	item.options
-	eq $1.log, ['o2']
+	eq $1.log, ['v1','o1','d1','d12','o2']
 	eq item.number, 2
-
+###
 
 class C < A
 	prop number
@@ -101,3 +104,4 @@ test do
 	let item = new E
 	item.desc3
 	eq $1.log, ['d1','d12','d123']
+###

--- a/test/apps/syntax/class-inherited.imba
+++ b/test/apps/syntax/class-inherited.imba
@@ -30,4 +30,5 @@ class Other < dynamic()
 		self
 
 test 'calling superclass.inherited' do
-	eq inherited, [Todo,Other]
+	yes # deprecated
+	# eq inherited, [Todo,Other]

--- a/test/apps/syntax/fields.imba
+++ b/test/apps/syntax/fields.imba
@@ -1,0 +1,90 @@
+class A
+	name
+	
+test do
+	let item = new A
+	ok item.hasOwnProperty('name')
+	eq item.name, undefined
+	
+class A2
+	name = 'hello'
+	
+test do
+	let item = new A2
+	eq item.name, 'hello'
+	
+class A3(name)
+	name = 'hello'
+	
+test do
+	let item = new A3('john')
+	eq item.name, 'john'
+
+class A4(...)
+	name = 'hello'
+	
+test do
+	let item = new A4(name: 'jane')
+	eq item.name, 'jane'
+
+class B
+	one = 1
+	two = 2
+	three = dynamic!
+	all = [one,two,three]
+	
+	def dynamic
+		3
+	
+test do
+	let item = new B
+	eq item.one, 1
+	eq item.two, 2
+	eq item.three, 3
+	eq item.all, [1,2,3]
+
+
+class C
+	static one
+	static type = 'cls'
+	
+test do
+	ok C.hasOwnProperty('one')
+	eq C.one, undefined
+	eq C.type, 'cls'
+
+
+class D(a,b)
+	a = 2
+	b = 2
+	mult = a * b
+
+	
+test do
+	let d = new D
+	eq d.mult, 4
+
+class D2(a,b)
+	a = 2
+	b = 2
+	mult = a * b
+
+test do
+	let d = new D2(3)
+	eq d.mult, 6
+
+class E
+	a = 2
+	b = 2
+	mult = a * b
+
+test do
+	let e = new E
+	eq e.mult, 4
+
+class F
+	key = 'f'
+	
+class G < F
+	val = 100
+

--- a/test/apps/syntax/fields.imba
+++ b/test/apps/syntax/fields.imba
@@ -82,9 +82,14 @@ test do
 	let e = new E
 	eq e.mult, 4
 
-class F
-	key = 'f'
-	
-class G < F
-	val = 100
 
+class F
+	a = 2
+	b = 2
+	util = {
+		mult: do a * b
+	}
+
+test do
+	let f = new F
+	eq f.util.mult!, 4


### PR DESCRIPTION
The previous implementation of properties was always creating getters+setters and used weakmaps to store the values. This is slow and too complicated. Now fields use the plain properties (when possible), and they are always set before the constructor like js fields.