### PR TITLE
Show help if imba cli is run without arguments

### DIFF
--- a/bin/imba.imba
+++ b/bin/imba.imba
@@ -77,6 +77,8 @@ def parseOptions options, extras = []
 	return options
 
 def run entry, o, extras
+	return cli.help! unless o.args.length > 0
+
 	let path = np.resolve(entry)
 	let srcdir = np.dirname(path)
 
@@ -155,7 +157,8 @@ def run entry, o, extras
 
 let binary = cli.storeOptionsAsProperties(false).version(imbapkg.version).name('imba')
 
-cli.command('run <script>', { isDefault: true })
+
+cli.command('run [script]', { isDefault: true })
 	.description('Imba')
 	.option("-w, --watch", "Continously build and watch project while running")
 	.option("-m, --minify", "Minify generated files")


### PR DESCRIPTION
Update the imba cli to show help if run without any arguments. I do this by making the script parameter optional for `imba run <script>` and catch if there is no arguments passed. 

Today:
```bash
➜  imba git:(imba-cli-no-args) ✗ imba
error: missing required argument 'script'
```

Tomorrow:
```
➜  imba git:(imba-cli-no-args) ✗ ./bin/imba
Usage: imba [options] [command]

Options:
  -V, --version             output the version number
  -h, --help                display help for command

Commands:
  run [options] [script]    Imba
  build [options] <script>  Build an imba/js/html entrypoint and their
                            dependencies
  serve [options] <script>  Spawn a webserver for an imba/js/html entrypoint
  create [project]          Create a new imba project from a template
  help [command]            display help for command
```