### PR TITLE
Add experimental support for class decorators

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+## unreleased
+* Add experimental support for class decorators
+
 ## 2.0.0-alpha.165
 * Reorganize prebuilt files for jspm support
 

--- a/src/compiler/grammar.imba1
+++ b/src/compiler/grammar.imba1
@@ -82,7 +82,7 @@ var grammar =
 	# Any list of statements and expressions, separated by line breaks or semicolons.
 	Body: [
 		o 'BODYSTART' do Block.new([])
-		o 'Line' do Block.new([A1])
+		o 'Line' do Block.new([]).add(A1)
 		# o 'HEADER Line' do Block.new([A2])
 		# o 'LeadingTerminator' do Block.new([Terminator.new(A1)])
 		o 'Body Terminator Line' do A1.break(A2).add(A3) # A3.prebreak(A2) # why not add as real nodes?!
@@ -118,6 +118,7 @@ var grammar =
 		# o 'HEADER' do Terminator.new(A1)
 		o 'Comment'
 		o 'Statement'
+		o 'Decorators'
 
 		o 'ImportDeclaration'
 		o 'ExportDeclaration'

--- a/src/compiler/nodes.imba1
+++ b/src/compiler/nodes.imba1
@@ -1717,6 +1717,7 @@ export class Block < ListNode
 		if let decorators = @decorators
 			@decorators = null
 			return decorators
+		return null
 
 	def loc
 		# rather indents, no?
@@ -3150,6 +3151,9 @@ export class ClassDeclaration < Code
 	def visit
 		# replace with some advanced lookup?
 		@body.@delimiter = ''
+		let blk = STACK.up(Block)
+		@decorators = blk and blk.collectDecorators
+		# console.log "FOUND DECORATORS FOR CLASS?",@decorators and @decorators:length
 
 		
 		STACK.pop(self)
@@ -3286,6 +3290,10 @@ export class ClassDeclaration < Code
 				
 			if !node.isStatic and restIndex != null
 				node.set(restIndex: restIndex)
+		
+		if !tsc and @decorators
+			let op = util.decorate(Arr.new(@decorators),THIS)
+			staticInits.add([op,BR])
 
 		for node,i in body
 			if node.@decorators
@@ -3338,29 +3346,30 @@ export class ClassDeclaration < Code
 		if !staticInits.isEmpty and !tsc
 			staticInit.inject(staticInits,0)
 			
-		let hasInitedHook = !!instanceMethodMap["#__inited__"]
-		
-		if !isTag and !ctor and hasInitedHook
-			let ops = sup ? [Super.new(),BR] : [BR]
-			ctor = addMethod('constructor',[],ops,{})
+		if !STACK.tsc
+			let hasInitedHook = !!instanceMethodMap["#__inited__"]
 			
-		if ctor and !isTag
-			# set a unique local symbol for this class			
-			let ctorsym = STACK.symbolFor('#__initor__')
-			let initsym = STACK.symbolFor('#__inited__')
+			if !isTag and !ctor and hasInitedHook
+				let ops = sup ? [Super.new(),BR] : [BR]
+				ctor = addMethod('constructor',[],ops,{})
+				
+			if ctor and !isTag
+				# set a unique local symbol for this class			
+				let ctorsym = STACK.symbolFor('#__initor__')
+				let initsym = STACK.symbolFor('#__inited__')
 
-			if sup
-				let refsym = STACK.getSymbol()
-				staticInit.inject LIT("this.prototype[{ctorsym}] = {refsym}"), 0
-				if hasInitedHook
-					ctor.inject LIT("if(this[{ctorsym}]==={refsym}) this[{initsym}]();")
-				else
-					ctor.inject LIT("this[{ctorsym}]==={refsym} && this[{initsym}] && this[{initsym}]()")
-			elif hasInitedHook
-				ctor.inject LIT("if(!this[{ctorsym}]) this[{initsym}]();")
+				if sup
+					let refsym = STACK.getSymbol()
+					staticInit.inject LIT("this.prototype[{ctorsym}] = {refsym}"), 0
+					if hasInitedHook
+						ctor.inject LIT("if(this[{ctorsym}]==={refsym}) this[{initsym}]();")
+					else
+						ctor.inject LIT("this[{ctorsym}]==={refsym} && this[{initsym}] && this[{initsym}]()")
+				elif hasInitedHook
+					ctor.inject LIT("if(!this[{ctorsym}]) this[{initsym}]();")
 
 
-			# ctor.body.add([callop,BR],0)
+				# ctor.body.add([callop,BR],0)
 
 		
 		self
@@ -5816,7 +5825,8 @@ export class Identifier < Node
 export class DecoratorIdentifier < Identifier
 	
 	def symbol
-		"decorator${@value.slice(1)}"
+		helpers.toValidIdentifier(String(@value))
+		# "decorator${@value.slice(1)}"
 		
 	def toString
 		symbol

--- a/src/utils/identifiers.imba
+++ b/src/utils/identifiers.imba
@@ -30,9 +30,10 @@ export const ToJSMap = {
 	'-': 'Ξ'
 	'?': 'Φ'
 	'#': 'Ψ'
+	'@': 'α'
 }
 
-const toJSregex = new RegExp("[\-\?\#]","gu")
+const toJSregex = new RegExp("[\-\?\#\@]","gu")
 const toJSreplacer = do(m) ToJSMap[m]
 
 export def toJSIdentifier raw
@@ -42,9 +43,10 @@ export const ToImbaMap = {
 	'Ξ': '-'
 	'Φ': '?'
 	'Ψ': '#'
+	'α': '@'
 }
 
-const toImbaRegex = new RegExp("[ΞΦΨ]","gu")
+const toImbaRegex = new RegExp("[ΞΦΨα]","gu")
 const toImbaReplacer = do(m) ToImbaMap[m]
 
 export def toImbaIdentifier raw

--- a/test/apps/syntax/class-decorators.imba
+++ b/test/apps/syntax/class-decorators.imba
@@ -1,0 +1,27 @@
+
+# decorator that adds a method to allow
+# using instances of a class as keys in
+# regular dictionaries. Useful hack :)
+def @indexable target
+	extend class target
+		def [Symbol.toPrimitive]
+			##symbol ||= Symbol!
+
+@indexable
+class Model
+	
+	def constructor
+		seed = Math.random!
+
+
+describe 'class decorators' do
+	test do
+		let data = {}
+		let one = new Model
+		let two = new Model
+
+		data[one] = 1
+		data[two] = 2
+		
+		eq data[one], 1
+		eq data[two], 2

--- a/test/proposals/class-decorators/index.imba
+++ b/test/proposals/class-decorators/index.imba
@@ -1,54 +1,23 @@
-def @register key
-	
-	
-	yes
-
-def @actionable target
+def @indexable target
 	extend class target
-		def hey
-			"WOW!"
-	yes
+		def [Symbol.toPrimitive]
+			##symbol ||= Symbol!
 
-def @eventable target
-	extend class target
-		def on name
-			"WOW!"
-		
-		def un name
-			yes
-			
-		def emit name, data
-			yes
-
-class Decorator
-	
-	def #property
-		yes
-		
-	def #method
-		yes
-		
-	def #class
-		yes
-		
-	def #tag
-		yes
-
-
-class Simple
-	def render
-		yes
-
-@actionable @eventable
-class Lock
+@indexable
+class Model
 	
 	def constructor
 		seed = Math.random!
-	
-	def test
-		seed.toFixed
-		yes
 
-let item = new Lock
-console.log item.hey!
-console.log item.on
+
+describe 'class decorators' do
+	test do
+	let data = {}
+	let one = new Model
+	let two = new Model
+
+	data[one] = 1
+	data[two] = 2
+	
+	eq data[one], 1
+	eq data[two], 2

--- a/test/proposals/class-decorators/index.imba
+++ b/test/proposals/class-decorators/index.imba
@@ -1,0 +1,54 @@
+def @register key
+	
+	
+	yes
+
+def @actionable target
+	extend class target
+		def hey
+			"WOW!"
+	yes
+
+def @eventable target
+	extend class target
+		def on name
+			"WOW!"
+		
+		def un name
+			yes
+			
+		def emit name, data
+			yes
+
+class Decorator
+	
+	def #property
+		yes
+		
+	def #method
+		yes
+		
+	def #class
+		yes
+		
+	def #tag
+		yes
+
+
+class Simple
+	def render
+		yes
+
+@actionable @eventable
+class Lock
+	
+	def constructor
+		seed = Math.random!
+	
+	def test
+		seed.toFixed
+		yes
+
+let item = new Lock
+console.log item.hey!
+console.log item.on


### PR DESCRIPTION
Very basic support for class decorators

```imba
# decorator that adds a method to allow
# using instances of a class as keys in
# regular dictionaries. Useful hack :)
def @indexable target
	extend class target
		def [Symbol.toPrimitive]
			#symbol ||= Symbol!

@indexable
class Model

let seen = {}
let item = new Model
seen[item] = true
```