### PR TITLE
Correct version flag from uppercase -V to lowercase -v.

### DIFF
--- a/bin/imba.imba
+++ b/bin/imba.imba
@@ -201,7 +201,7 @@ def run entry, o, extras
 				runner.reload!
 	return
 
-let binary = cli.storeOptionsAsProperties(false).version(imbapkg.version).name('imba')
+let binary = cli.storeOptionsAsProperties(false).version(imbapkg.version, '-v, --version').name('imba')
 
 def common cmd
 	cmd


### PR DESCRIPTION
## Description

Change version flag from uppercase -V to lowercase -v.
The default for commander.js is uppercase -V.

It fixes issue https://github.com/imba/imba/issues/599 .

## How Has This Been Tested?

npm run test: 350 tests passed
Platform: Windows 10.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
Technically could break code that relies on uppercase -V to get the version number from imba, but is this something that should  be relied upon? In that case both options (-v, -V (and --version)) should be accepted. Let me know.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
