### PR TITLE
Hotkeys

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 - Fix: Allow binding tag properties to symbol identifiers
 - Report correct location for "Cannot redeclare variable" error (#114)
+- Experimental support for `@hotkey` events
+- Fix: Don't run `imba.commit` on unhandled events>
+- Added `@trusted` event guard
+- Added `@trap` event modifier
 
 ## 2.0.0-alpha.172
 

--- a/src/compiler/nodes.imba1
+++ b/src/compiler/nodes.imba1
@@ -129,6 +129,9 @@ export var F =
 	DIFF_FLAGS: 2 ** 1
 	DIFF_ATTRS: 2 ** 2
 	DIFF_CHILDREN: 2 ** 3
+	DIFF_MODIFIERS: 2 ** 4
+	DIFF_INLINE: 2 ** 5
+	
 
 
 # Helpers for operators
@@ -8373,6 +8376,7 @@ class TagLike < Node
 		@cvar or (@parent ? @parent.cvar :  tagvar('C'))
 
 	def vvar do tagvar('V') # value variable
+	def hvar do tagvar('H') # handler variable
 	def kvar do tagvar('K') # key variable
 
 	# for tracking specific changes -- included in end
@@ -9383,15 +9387,21 @@ export class Tag < TagLike
 				elif item isa TagHandler
 					let mods = item.modifiers
 					let specials = mods.extractDynamics()
-	
-					add "{vvar} = {iref} || ({iref}={mods.c(o)})"
+					let visit = no
+					add "{hvar} = {iref} || ({iref}={mods.c(o)})"
 					for special in specials
 						let k = special.option(:key)
 						let i = special.option(:index)
-						add "{OP('.',vvar,k).c}[{i}]={special.c(o)}"
+						let path = "{OP('.',hvar,k).c}[{i}]"
+						if k == 'options'
+							visit = yes
+							add "({vvar}={special.c(o)},{vvar}==={path} || ({path}={vvar},{dvar}|={F.DIFF_MODIFIERS}|{F.DIFF_INLINE}))"
+						else
+							add "{path}={special.c(o)}"
 
-					mods = vvar
-					add "{bvar} || {ref}.on$({item.quoted},{mods.c},{scope__.context.c})"
+					add "{bvar} || {ref}.on$({item.quoted},{hvar.c},{scope__.context.c})"
+					if visit
+						add "{dvar}&{F.DIFF_INLINE} && ({dvar}^={F.DIFF_INLINE},{hvar}[{gsym('#visit')}]?.())"
 
 				elif item isa TagAttr and item.ns == 'bind'
 					

--- a/src/compiler/nodes.imba1
+++ b/src/compiler/nodes.imba1
@@ -68,6 +68,7 @@ var CUSTOM_EVENTS = {
 	intersect: 'events_intersect'
 	selection: 'events_selection'
 	resize: 'events_resize'
+	hotkey: 'events_hotkey'
 	touch: 'events_pointer'
 	pointer: 'events_pointer'
 	pointerdown: 'events_pointer'

--- a/src/compiler/theme.imba
+++ b/src/compiler/theme.imba
@@ -26,6 +26,7 @@ export const modifiers =
 	focus: {}
 	focin: {name: 'focus-within'}
 	'focus-within': {}
+	'focus-visible': {}
 	hover: {}
 	indeterminate: {}
 	'in-range': {}

--- a/src/imba/events/core.imba
+++ b/src/imba/events/core.imba
@@ -120,6 +120,9 @@ export class EventHandler
 		
 	get silent?
 		params.silent
+		
+	get global?
+		params.global
 
 	def handleEvent event
 		let target = event.#target or event.target
@@ -215,10 +218,6 @@ export class EventHandler
 				event.stopImmediatePropagation()
 				event.#defaultPrevented = yes
 				event.preventDefault()
-
-			elif handler == 'continue'
-				event.#stopPropagation = no
-				event.#defaultPrevented = no
 
 			elif handler == 'stop'
 				event.#stopPropagation = yes

--- a/src/imba/events/core.imba
+++ b/src/imba/events/core.imba
@@ -110,7 +110,7 @@ export class EventHandler
 	def un name, ...params do unlisten(self,name,...params)
 
 	def handleEvent event
-		let target = event.target
+		let target = event.#target or event.target
 		let element = #target or event.currentTarget
 		let mods = self.params
 		let i = 0
@@ -131,6 +131,8 @@ export class EventHandler
 			commit: null
 			current: null
 		}
+		
+		# console.log 'handling event',event.target,event.currentTarget
 
 		state.current = state
 
@@ -193,10 +195,21 @@ export class EventHandler
 				args.unshift(m[2])
 				handler = m[1]
 
-			# check if it is an array?
-			if handler == 'stop'
+			if handler == 'trap'
+				event.#stopPropagation = yes
+				event.stopImmediatePropagation()
+				event.#defaultPrevented = yes
+				event.preventDefault()
+
+			elif handler == 'continue'
+				event.#stopPropagation = no
+				event.#defaultPrevented = no
+
+			elif handler == 'stop'
+				event.#stopPropagation = yes
 				event.stopImmediatePropagation()
 			elif handler == 'prevent'
+				event.#defaultPrevented = yes
 				event.preventDefault()
 			elif handler == 'commit'
 				state.commit = yes

--- a/src/imba/events/core.imba
+++ b/src/imba/events/core.imba
@@ -19,9 +19,12 @@ export const events = {}
 
 export def use_events
 	yes
+	
+def Event.trusted$mod
+	return !!event.isTrusted
 
 def Event.log$mod ...params
-	console.log(...params)
+	console.info(...params)
 	return true
 
 # Skip unless matching selector
@@ -75,6 +78,7 @@ def Event.flag$mod name,sel
 	return true unless el
 	let step = step
 	state[step] = id
+	commit = yes
 
 	el.flags.incr(name)
 
@@ -90,7 +94,6 @@ def Event.busy$mod sel
 	return Event.flag$mod.call(this,'busy',250,sel)
 
 def Event.mod$mod name
-	# FIXME
 	return Event.flag$mod.call(this,"mod-{name}",global.document.documentElement)
 
 # could cache similar event handlers with the same parts
@@ -108,6 +111,15 @@ export class EventHandler
 	def on name, ...params do listen(self,name,...params)
 	def once name, ...params do once(self,name,...params)
 	def un name, ...params do unlisten(self,name,...params)
+		
+	get passive?
+		params.passive
+		
+	get capture?
+		params.capture
+		
+	get silent?
+		params.silent
 
 	def handleEvent event
 		let target = event.#target or event.target
@@ -116,6 +128,7 @@ export class EventHandler
 		let i = 0
 		let awaited = no
 		let prevRes = undefined
+		let silence = mods.silence or mods.silent
 		
 		self.count ||= 0
 		self.state ||= {}
@@ -160,7 +173,6 @@ export class EventHandler
 				handler = handler.split('~')[0]
 			
 			let modargs = null
-			let ismod = no
 			let args = [event,state]
 			let res = undefined
 			let context = null
@@ -168,9 +180,12 @@ export class EventHandler
 			let isstring = typeof handler == 'string'
 			
 			if handler[0] == '$' and handler[1] == '_' and val[0] isa Function
+				# handlers should commit by default
 				handler = val[0]
+				state.commit = yes unless handler.passive
 				args = [event,state].concat(val.slice(1))
 				context = element
+				
 
 			# parse the arguments
 			elif val isa Array
@@ -213,8 +228,6 @@ export class EventHandler
 				event.preventDefault()
 			elif handler == 'commit'
 				state.commit = yes
-			elif handler == 'silence' or handler == 'silent'
-				state.commit = no
 			elif handler == 'ctrl'
 				break unless event.ctrlKey
 			elif handler == 'alt'
@@ -226,7 +239,7 @@ export class EventHandler
 			elif handler == 'once'
 				# clean up bound data as well
 				element.removeEventListener(event.type,self)
-			elif handler == 'options'
+			elif handler == 'options' or handler == 'silence' or handler == 'silent'
 				continue
 
 			elif keyCodes[handler]
@@ -248,13 +261,13 @@ export class EventHandler
 					handler = fn
 					context = state
 					args = modargs or []
-					ismod = yes
 
 				# should default to first look at closure - no?
 				elif handler[0] == '_'
 					handler = handler.slice(1)
 					context = self.closure
 				else
+					# TODO deprecate this functionality and warn about it?
 					context = self.getHandlerForMethod(element,handler)
 
 			if handler isa Function
@@ -262,11 +275,8 @@ export class EventHandler
 			elif context
 				res = context[handler].apply(context,args)
 
-			if state.commit === null and !ismod
-				state.commit = yes
-
 			if res and res.then isa Function and res != scheduler.$promise
-				scheduler.commit! if state.commit
+				scheduler.commit! if state.commit and !silence
 				awaited = yes
 				# TODO what if await fails?
 				res = await res
@@ -278,7 +288,7 @@ export class EventHandler
 		
 		emit(state,'end',state)
 
-		scheduler.commit! if state.commit
+		scheduler.commit! if state.commit and !silence
 
 		self.currentEvents.delete(event)
 		if self.currentEvents.size == 0
@@ -296,7 +306,7 @@ extend class Element
 
 		handler = new EventHandler(mods,scope)
 
-		let capture = mods.capture
+		let capture = mods.capture or no
 		let passive = mods.passive
 
 		let o = capture

--- a/src/imba/events/hotkey.imba
+++ b/src/imba/events/hotkey.imba
@@ -1,0 +1,220 @@
+import {Event,CustomEvent,Element} from '../dom/core'
+
+export def use_events_hotkey
+	yes
+
+const KeyLabels = {
+	esc: '⎋'
+	enter: '⏎'
+	shift: '⇧'
+	command: '⌘'
+	option: '⌥'
+	alt: '⎇'
+	del: '⌦'
+	backspace: '⌫'
+
+}
+
+const Globals = {
+	"command+1": yes
+	"command+2": yes
+	"command+3": yes
+	"command+4": yes
+	"command+5": yes
+	"command+6": yes
+	"command+7": yes
+	"command+8": yes
+	"command+9": yes
+	"command+0": yes
+	"command+n": yes
+	"command+f": yes
+	"command+k": yes
+	"command+j": yes
+	"command+s": yes
+	"esc": yes
+	"shift+command+f": yes
+}
+
+import Mousetrap from './mousetrap'
+
+const stopCallback = do |e,el,combo|	
+	if (' ' + el.className + ' ').indexOf(' mousetrap ') > -1
+		return false
+		
+	if el.mousetrappable
+		return false
+
+	if el.tagName == 'INPUT' && (combo == 'down' or combo == 'up')
+		return false
+	
+	if el.tagName == 'INPUT' || el.tagName == 'SELECT' || el.tagName == 'TEXTAREA'
+		if Globals[combo]
+			e.#globalHotkey = yes
+			e.#inFormInput = yes
+			return false
+		return true
+		
+	if el.contentEditable && (el.contentEditable == 'true' || el.contentEditable == 'plaintext-only' || el.closest('.editable'))
+		if Globals[combo]
+			e.#globalHotkey = yes
+			e.#inContentEditable = yes
+			return false
+		return true
+		
+	return false
+
+export const hotkeys = new class HotKeyManager
+	def constructor
+		combos = {'*': {}}
+		identifiers = {}
+		labels = {}
+		handler = handle.bind(self)
+		mousetrap = null
+		hothandler = handle.bind(self)
+
+	def register key,mods = {}
+		unless mousetrap
+			mousetrap = Mousetrap(document)
+			mousetrap.stopCallback = stopCallback
+
+		unless combos[key]
+			combos[key] = yes
+			mousetrap.bind(key,handler)
+
+		if mods.global
+			Globals[key] = yes
+		self
+		
+	def comboIdentifier combo
+		identifiers[combo] ||= combo.replace(/\+/g,'_').replace(/\ /g,'-').replace(/\*/g,'all')
+
+	def shortcutHTML combo
+		("<u>" + comboLabel(combo).split(" ").join("</u><u>") + "</u>").replace('<u>/</u>','<span>or</span>')
+		
+	def comboLabel combo
+		labels[combo] ||= combo.split(" ").map(do $1.split("+").map(do KeyLabels[$1] or $2.toUpperCase!).join("") ).join(" ")
+		
+	def matchCombo str
+		yes
+
+	def handle e\Event, combo
+		# e is the original event
+		let source = e.target.#hotkeyTarget or e.target
+		let targets\HTMLElement[] = Array.from(document.querySelectorAll('[data-hotkey]'))
+		let root = source.ownerDocument
+		let group = source
+		
+		# find the closest hotkey 
+		while group and group != root
+			if group.hotkeys === true
+				break
+			group = group.parentNode
+			
+		if group == root
+			group = source
+		
+		targets = targets.reverse!.filter do |el|
+			return no unless el.#hotkeyCombos and el.#hotkeyCombos[combo]
+			return no if el.closest('.hiding,.no-hotkeys')
+
+			let par = el
+			while par and par != root
+				if par.hotkeys === false
+					return no
+				par = par.parentNode
+			return yes
+			
+		return unless targets.length
+	
+		let detail = {combo: combo, originalEvent: e, targets: targets}
+		let event = new CustomEvent('hotkey', bubbles: true, detail: detail)
+		event.originalEvent = e
+
+		event.handle$mod = do(options)
+			let el = this.element
+			if !this.handler.#combos[combo]
+				return false
+
+			if e.#globalHotkey and !this.modifiers.global
+				return false
+
+			if !group.contains(el) and !el.contains(group) and !this.modifiers.global
+				return false
+
+			return true
+		
+		let res = source.dispatchEvent(event)
+
+		# global.ce = event
+		for receiver in targets
+			for handler in receiver.#hotkeyHandlers
+				unless event.#stopPropagation
+					handler.handleEvent(event)
+
+			if event.#defaultPrevented or event.#stopPropagation
+				e.preventDefault!
+
+			if false and receiver.matches('input:not([type=button]),select,textarea')
+				e.preventDefault!
+				receiver.focus! if receiver.focus
+			else
+				yes
+				# if params.within and !receiver.parentNode.contains(document.activeElement)
+				# 	continue
+				# if (/command|cmd|ctrl|shift/).test(combo) or params.prevent
+				# 	e.preventDefault!
+				# console.log 'emit click!'
+				# receiver.click!
+
+			if event.#stopPropagation
+				break
+		self
+
+extend class Element
+		
+	def on$hotkey mods, scope, handler, o
+		#hotkeyHandlers ||= []
+		#hotkeyHandlers.push(handler)
+		# addEventListener('hotkey',handler,o)
+		console.log "HOTKEY",mods.options,mods
+		handler.#target = self
+		#updateHotKeys!
+		return handler
+		
+	def #updateHotKeys
+		let all = {}
+		let isMac = global.navigator.platform == 'MacIntel'
+		for handler in #hotkeyHandlers
+			let mods = handler.params
+			let key = mods.options[0]
+			let prev = handler.#key
+			if handler.#key =? key
+				handler.#combos = {}
+				let combos = key.replace(/\bmod\b/g,isMac ? 'command' : 'ctrl')
+				for combo in combos.split('|')
+					hotkeys.register(combo,mods)
+					handler.#combos[combo] = yes
+			Object.assign(all,handler.#combos)
+
+		let keys = Object.keys(all)
+		#hotkeyCombos = all
+		dataset.hotkey = keys.join(' ')
+		self
+
+def Event.hotkey$click
+	this.element.click!
+	return yes
+	
+def Event.hotkey$focus expr
+	let el = this.element
+	let doc = el.ownerDocument
+	
+	if expr
+		el = el.querySelector(expr) or el.closest(expr) or doc.querySelector(expr)
+
+	if el == doc.body
+		doc.activeElement.blur! unless doc.activeElement == doc.body
+	else
+		el.focus!
+		
+	return yes

--- a/src/imba/events/hotkey.imba
+++ b/src/imba/events/hotkey.imba
@@ -203,10 +203,6 @@ extend class Element
 		#hotkeyCombos = all
 		dataset.hotkey = keys.join(' ')
 		self
-
-def Event.hotkey$click
-	this.element.click!
-	return yes
 	
 def Event.hotkey$focus expr
 	let el = this.element

--- a/src/imba/events/hotkey.imba
+++ b/src/imba/events/hotkey.imba
@@ -85,7 +85,7 @@ export const hotkeys = new class HotKeyManager
 		self
 		
 	def comboIdentifier combo
-		identifiers[combo] ||= combo.replace(/\+/g,'_').replace(/\ /g,'-').replace(/\*/g,'all')
+		identifiers[combo] ||= combo.replace(/\+/g,'_').replace(/\ /g,'-').replace(/\*/g,'all').replace(/\|/g,' ')
 
 	def shortcutHTML combo
 		("<u>" + comboLabel(combo).split(" ").join("</u><u>") + "</u>").replace('<u>/</u>','<span>or</span>')
@@ -128,6 +128,7 @@ export const hotkeys = new class HotKeyManager
 		let detail = {combo: combo, originalEvent: e, targets: targets}
 		let event = new CustomEvent('hotkey', bubbles: true, detail: detail)
 		event.originalEvent = e
+		event.hotkey = combo
 
 		event.handle$mod = do(options)
 			let el = this.element
@@ -178,19 +179,21 @@ extend class Element
 		handler.#target = self
 		# add a default handler
 		mods.$_ ||= [DefaultHandler]
+		
+		mods.#visit = do #updateHotKeys!
 		#updateHotKeys!
 		return handler
 		
 	def #updateHotKeys
 		let all = {}
-		let isMac = global.navigator.platform == 'MacIntel'
+		let isApple = (global.navigator.platform or '').match(/iPhone|iPod|iPad|Mac/)
 		for handler in #hotkeyHandlers
 			let mods = handler.params
 			let key = mods.options[0]
 			let prev = handler.#key
 			if handler.#key =? key
 				handler.#combos = {}
-				let combos = key.replace(/\bmod\b/g,isMac ? 'command' : 'ctrl')
+				let combos = key.replace(/\bmod\b/g,isApple ? 'command' : 'ctrl')
 				for combo in combos.split('|')
 					hotkeys.register(combo,mods)
 					handler.#combos[combo] = yes

--- a/src/imba/events/hotkey.node.imba
+++ b/src/imba/events/hotkey.node.imba
@@ -1,0 +1,2 @@
+export def use_events_hotkey
+	yes

--- a/src/imba/events/mousetrap.mjs
+++ b/src/imba/events/mousetrap.mjs
@@ -1,0 +1,1065 @@
+/**
+ * Copyright 2012-2017 Craig Campbell
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Mousetrap is a simple keyboard shortcut library for Javascript with
+ * no external dependencies
+ *
+ * @version 1.6.1
+ * @url craig.is/killing/mice
+ */
+/**
+ * mapping of special keycodes to their corresponding keys
+ *
+ * everything in this dictionary cannot use keypress events
+ * so it has to be here to map to the correct keycodes for
+ * keyup/keydown events
+ *
+ * @type {Object}
+ */
+var _MAP = {
+  8: "backspace",
+  9: "tab",
+  13: "enter",
+  16: "shift",
+  17: "ctrl",
+  18: "alt",
+  20: "capslock",
+  27: "esc",
+  32: "space",
+  33: "pageup",
+  34: "pagedown",
+  35: "end",
+  36: "home",
+  37: "left",
+  38: "up",
+  39: "right",
+  40: "down",
+  45: "ins",
+  46: "del",
+  91: "meta",
+  93: "meta",
+  224: "meta",
+};
+
+/**
+ * mapping for special characters so they can support
+ *
+ * this dictionary is only used incase you want to bind a
+ * keyup or keydown event to one of these keys
+ *
+ * @type {Object}
+ */
+var _KEYCODE_MAP = {
+  106: "*",
+  107: "+",
+  109: "-",
+  110: ".",
+  111: "/",
+  186: ";",
+  187: "=",
+  188: ",",
+  189: "-",
+  190: ".",
+  191: "/",
+  192: "`",
+  219: "[",
+  220: "\\",
+  221: "]",
+  222: "'",
+};
+
+/**
+ * this is a mapping of keys that require shift on a US keypad
+ * back to the non shift equivelents
+ *
+ * this is so you can use keyup events with these keys
+ *
+ * note that this will only work reliably on US keyboards
+ *
+ * @type {Object}
+ */
+var _SHIFT_MAP = {
+  "~": "`",
+  "!": "1",
+  "@": "2",
+  "#": "3",
+  $: "4",
+  "%": "5",
+  "^": "6",
+  "&": "7",
+  "*": "8",
+  "(": "9",
+  ")": "0",
+  _: "-",
+  "+": "=",
+  ":": ";",
+  '"': "'",
+  "<": ",",
+  ">": ".",
+  "?": "/",
+  "|": "\\",
+};
+
+/**
+ * this is a list of special strings you can use to map
+ * to modifier keys when you specify your keyboard shortcuts
+ *
+ * @type {Object}
+ */
+var _SPECIAL_ALIASES = {
+  option: "alt",
+  command: "meta",
+  return: "enter",
+  escape: "esc",
+  plus: "+",
+  mod: /Mac|iPod|iPhone|iPad/.test(navigator.platform) ? "meta" : "ctrl",
+};
+
+/**
+ * variable to store the flipped version of _MAP from above
+ * needed to check if we should use keypress or not when no action
+ * is specified
+ *
+ * @type {Object|undefined}
+ */
+var _REVERSE_MAP;
+
+/**
+ * loop through the f keys, f1 to f19 and add them to the map
+ * programatically
+ */
+for (var i = 1; i < 20; ++i) {
+  _MAP[111 + i] = "f" + i;
+}
+
+/**
+ * loop through to map numbers on the numeric keypad
+ */
+for (i = 0; i <= 9; ++i) {
+  // This needs to use a string cause otherwise since 0 is falsey
+  // mousetrap will never fire for numpad 0 pressed as part of a keydown
+  // event.
+  //
+  // @see https://github.com/ccampbell/mousetrap/pull/258
+  _MAP[i + 96] = i.toString();
+}
+
+/**
+ * cross browser add event method
+ *
+ * @param {Element|HTMLDocument} object
+ * @param {string} type
+ * @param {Function} callback
+ * @returns void
+ */
+function _addEvent(object, type, callback) {
+  if (object.addEventListener) {
+    object.addEventListener(type, callback, false);
+    return;
+  }
+
+  object.attachEvent("on" + type, callback);
+}
+
+function _removeEvent(object, type, callback) {
+  if (object.removeEventListener) {
+    object.removeEventListener(type, callback, false);
+    return;
+  }
+
+  object.detachEvent("on" + type, callback);
+}
+
+/**
+ * takes the event and returns the key character
+ *
+ * @param {Event} e
+ * @return {string}
+ */
+function _characterFromEvent(e) {
+  // for keypress events we should return the character as is
+  if (e.type == "keypress") {
+    var character = String.fromCharCode(e.which);
+
+    // if the shift key is not pressed then it is safe to assume
+    // that we want the character to be lowercase.  this means if
+    // you accidentally have caps lock on then your key bindings
+    // will continue to work
+    //
+    // the only side effect that might not be desired is if you
+    // bind something like 'A' cause you want to trigger an
+    // event when capital A is pressed caps lock will no longer
+    // trigger the event.  shift+a will though.
+    if (!e.shiftKey) {
+      character = character.toLowerCase();
+    }
+
+    return character;
+  }
+
+  // for non keypress events the special maps are needed
+  if (_MAP[e.which]) {
+    return _MAP[e.which];
+  }
+
+  if (_KEYCODE_MAP[e.which]) {
+    return _KEYCODE_MAP[e.which];
+  }
+
+  // if it is not in the special map
+
+  // with keydown and keyup events the character seems to always
+  // come in as an uppercase character whether you are pressing shift
+  // or not.  we should make sure it is always lowercase for comparisons
+  return String.fromCharCode(e.which).toLowerCase();
+}
+
+/**
+ * checks if two arrays are equal
+ *
+ * @param {Array} modifiers1
+ * @param {Array} modifiers2
+ * @returns {boolean}
+ */
+function _modifiersMatch(modifiers1, modifiers2) {
+  return modifiers1.sort().join(",") === modifiers2.sort().join(",");
+}
+
+/**
+ * takes a key event and figures out what the modifiers are
+ *
+ * @param {Event} e
+ * @returns {Array}
+ */
+function _eventModifiers(e) {
+  var modifiers = [];
+
+  if (e.shiftKey) {
+    modifiers.push("shift");
+  }
+
+  if (e.altKey) {
+    modifiers.push("alt");
+  }
+
+  if (e.ctrlKey) {
+    modifiers.push("ctrl");
+  }
+
+  if (e.metaKey) {
+    modifiers.push("meta");
+  }
+
+  return modifiers;
+}
+
+/**
+ * prevents default for this event
+ *
+ * @param {Event} e
+ * @returns void
+ */
+function _preventDefault(e) {
+  if (e.preventDefault) {
+    e.preventDefault();
+    return;
+  }
+
+  e.returnValue = false;
+}
+
+/**
+ * stops propogation for this event
+ *
+ * @param {Event} e
+ * @returns void
+ */
+function _stopPropagation(e) {
+  if (e.stopPropagation) {
+    e.stopPropagation();
+    return;
+  }
+
+  e.cancelBubble = true;
+}
+
+/**
+ * determines if the keycode specified is a modifier key or not
+ *
+ * @param {string} key
+ * @returns {boolean}
+ */
+function _isModifier(key) {
+  return key == "shift" || key == "ctrl" || key == "alt" || key == "meta";
+}
+
+/**
+ * reverses the map lookup so that we can look for specific keys
+ * to see what can and can't use keypress
+ *
+ * @return {Object}
+ */
+function _getReverseMap() {
+  if (!_REVERSE_MAP) {
+    _REVERSE_MAP = {};
+    for (var key in _MAP) {
+      // pull out the numeric keypad from here cause keypress should
+      // be able to detect the keys from the character
+      if (key > 95 && key < 112) {
+        continue;
+      }
+
+      if (_MAP.hasOwnProperty(key)) {
+        _REVERSE_MAP[_MAP[key]] = key;
+      }
+    }
+  }
+  return _REVERSE_MAP;
+}
+
+/**
+ * picks the best action based on the key combination
+ *
+ * @param {string} key - character for key
+ * @param {Array} modifiers
+ * @param {string=} action passed in
+ */
+function _pickBestAction(key, modifiers, action) {
+  // if no action was picked in we should try to pick the one
+  // that we think would work best for this key
+  if (!action) {
+    action = _getReverseMap()[key] ? "keydown" : "keypress";
+  }
+
+  // modifier keys don't work as expected with keypress,
+  // switch to keydown
+  if (action == "keypress" && modifiers.length) {
+    action = "keydown";
+  }
+
+  return action;
+}
+
+/**
+ * Converts from a string key combination to an array
+ *
+ * @param  {string} combination like "command+shift+l"
+ * @return {Array}
+ */
+function _keysFromString(combination) {
+  if (combination === "+") {
+    return ["+"];
+  }
+
+  combination = combination.replace(/\+{2}/g, "+plus");
+  return combination.split("+");
+}
+
+/**
+ * Gets info for a specific key combination
+ *
+ * @param  {string} combination key combination ("command+s" or "a" or "*")
+ * @param  {string=} action
+ * @returns {Object}
+ */
+function _getKeyInfo(combination, action) {
+  var keys;
+  var key;
+  var i;
+  var modifiers = [];
+
+  // take the keys from this pattern and figure out what the actual
+  // pattern is all about
+  keys = _keysFromString(combination);
+
+  for (i = 0; i < keys.length; ++i) {
+    key = keys[i];
+
+    // normalize key names
+    if (_SPECIAL_ALIASES[key]) {
+      key = _SPECIAL_ALIASES[key];
+    }
+
+    // if this is not a keypress event then we should
+    // be smart about using shift keys
+    // this will only work for US keyboards however
+    if (action && action != "keypress" && _SHIFT_MAP[key]) {
+      key = _SHIFT_MAP[key];
+      modifiers.push("shift");
+    }
+
+    // if this key is a modifier then add it to the list of modifiers
+    if (_isModifier(key)) {
+      modifiers.push(key);
+    }
+  }
+
+  // depending on what the key combination is
+  // we will try to pick the best event for it
+  action = _pickBestAction(key, modifiers, action);
+
+  return {
+    key: key,
+    modifiers: modifiers,
+    action: action,
+  };
+}
+
+function _belongsTo(element, ancestor) {
+  if (element === null || element === document) {
+    return false;
+  }
+
+  if (element === ancestor) {
+    return true;
+  }
+
+  return _belongsTo(element.parentNode, ancestor);
+}
+
+export default function Mousetrap(targetElement) {
+  var self = this;
+
+  targetElement = targetElement || document;
+
+  if (!(self instanceof Mousetrap)) {
+    return new Mousetrap(targetElement);
+  }
+
+  /**
+   * element to attach key events to
+   *
+   * @type {Element}
+   */
+  self.target = targetElement;
+
+  /**
+   * a list of all the callbacks setup via Mousetrap.bind()
+   *
+   * @type {Object}
+   */
+  self._callbacks = {};
+
+  /**
+   * direct map of string combinations to callbacks used for trigger()
+   *
+   * @type {Object}
+   */
+  self._directMap = {};
+
+  /**
+   * keeps track of what level each sequence is at since multiple
+   * sequences can start out with the same sequence
+   *
+   * @type {Object}
+   */
+  var _sequenceLevels = {};
+
+  /**
+   * variable to store the setTimeout call
+   *
+   * @type {null|number}
+   */
+  var _resetTimer;
+
+  /**
+   * temporary state where we will ignore the next keyup
+   *
+   * @type {boolean|string}
+   */
+  var _ignoreNextKeyup = false;
+
+  /**
+   * temporary state where we will ignore the next keypress
+   *
+   * @type {boolean}
+   */
+  var _ignoreNextKeypress = false;
+
+  /**
+   * are we currently inside of a sequence?
+   * type of action ("keyup" or "keydown" or "keypress") or false
+   *
+   * @type {boolean|string}
+   */
+  var _nextExpectedAction = false;
+
+  /**
+   * resets all sequence counters except for the ones passed in
+   *
+   * @param {Object} doNotReset
+   * @returns void
+   */
+  function _resetSequences(doNotReset) {
+    doNotReset = doNotReset || {};
+
+    var activeSequences = false,
+      key;
+
+    for (key in _sequenceLevels) {
+      if (doNotReset[key]) {
+        activeSequences = true;
+        continue;
+      }
+      _sequenceLevels[key] = 0;
+    }
+
+    if (!activeSequences) {
+      _nextExpectedAction = false;
+    }
+  }
+
+  /**
+   * finds all callbacks that match based on the keycode, modifiers,
+   * and action
+   *
+   * @param {string} character
+   * @param {Array} modifiers
+   * @param {Event|Object} e
+   * @param {string=} sequenceName - name of the sequence we are looking for
+   * @param {string=} combination
+   * @param {number=} level
+   * @returns {Array}
+   */
+  function _getMatches(
+    character,
+    modifiers,
+    e,
+    sequenceName,
+    combination,
+    level
+  ) {
+    var i;
+    var callback;
+    var matches = [];
+    var action = e.type;
+
+    // if there are no events related to this keycode
+    if (!self._callbacks[character]) {
+      return [];
+    }
+
+    // if a modifier key is coming up on its own we should allow it
+    if (action == "keyup" && _isModifier(character)) {
+      modifiers = [character];
+    }
+
+    // loop through all callbacks for the key that was pressed
+    // and see if any of them match
+    for (i = 0; i < self._callbacks[character].length; ++i) {
+      callback = self._callbacks[character][i];
+
+      // if a sequence name is not specified, but this is a sequence at
+      // the wrong level then move onto the next match
+      if (
+        !sequenceName &&
+        callback.seq &&
+        _sequenceLevels[callback.seq] != callback.level
+      ) {
+        continue;
+      }
+
+      // if the action we are looking for doesn't match the action we got
+      // then we should keep going
+      if (action != callback.action) {
+        continue;
+      }
+
+      // if this is a keypress event and the meta key and control key
+      // are not pressed that means that we need to only look at the
+      // character, otherwise check the modifiers as well
+      //
+      // chrome will not fire a keypress if meta or control is down
+      // safari will fire a keypress if meta or meta+shift is down
+      // firefox will fire a keypress if meta or control is down
+      if (
+        (action == "keypress" && !e.metaKey && !e.ctrlKey) ||
+        _modifiersMatch(modifiers, callback.modifiers)
+      ) {
+        // when you bind a combination or sequence a second time it
+        // should overwrite the first one.  if a sequenceName or
+        // combination is specified in this call it does just that
+        //
+        // @todo make deleting its own method?
+        var deleteCombo = !sequenceName && callback.combo == combination;
+        var deleteSequence =
+          sequenceName &&
+          callback.seq == sequenceName &&
+          callback.level == level;
+        if (deleteCombo || deleteSequence) {
+          self._callbacks[character].splice(i, 1);
+        }
+
+        matches.push(callback);
+      }
+    }
+
+    return matches;
+  }
+
+  /**
+   * actually calls the callback function
+   *
+   * if your callback function returns false this will use the jquery
+   * convention - prevent default and stop propogation on the event
+   *
+   * @param {Function} callback
+   * @param {Event} e
+   * @returns void
+   */
+  function _fireCallback(callback, e, combo, sequence) {
+    // if this event should not happen stop here
+    if (self.stopCallback(e, e.target || e.srcElement, combo, sequence)) {
+      return;
+    }
+
+    if (callback(e, combo) === false) {
+      _preventDefault(e);
+      _stopPropagation(e);
+    }
+  }
+
+  /**
+   * handles a character key event
+   *
+   * @param {string} character
+   * @param {Array} modifiers
+   * @param {Event} e
+   * @returns void
+   */
+  self._handleKey = function (character, modifiers, e) {
+    var callbacks = _getMatches(character, modifiers, e);
+    var i;
+    var doNotReset = {};
+    var maxLevel = 0;
+    var processedSequenceCallback = false;
+
+    // Calculate the maxLevel for sequences so we can only execute the longest callback sequence
+    for (i = 0; i < callbacks.length; ++i) {
+      if (callbacks[i].seq) {
+        maxLevel = Math.max(maxLevel, callbacks[i].level);
+      }
+    }
+
+    // loop through matching callbacks for this key event
+    for (i = 0; i < callbacks.length; ++i) {
+      // fire for all sequence callbacks
+      // this is because if for example you have multiple sequences
+      // bound such as "g i" and "g t" they both need to fire the
+      // callback for matching g cause otherwise you can only ever
+      // match the first one
+      if (callbacks[i].seq) {
+        // only fire callbacks for the maxLevel to prevent
+        // subsequences from also firing
+        //
+        // for example 'a option b' should not cause 'option b' to fire
+        // even though 'option b' is part of the other sequence
+        //
+        // any sequences that do not match here will be discarded
+        // below by the _resetSequences call
+        if (callbacks[i].level != maxLevel) {
+          continue;
+        }
+
+        processedSequenceCallback = true;
+
+        // keep a list of which sequences were matches for later
+        doNotReset[callbacks[i].seq] = 1;
+        _fireCallback(
+          callbacks[i].callback,
+          e,
+          callbacks[i].combo,
+          callbacks[i].seq
+        );
+        continue;
+      }
+
+      // if there were no sequence matches but we are still here
+      // that means this is a regular match so we should fire that
+      if (!processedSequenceCallback) {
+        _fireCallback(callbacks[i].callback, e, callbacks[i].combo);
+      }
+    }
+
+    // if the key you pressed matches the type of sequence without
+    // being a modifier (ie "keyup" or "keypress") then we should
+    // reset all sequences that were not matched by this event
+    //
+    // this is so, for example, if you have the sequence "h a t" and you
+    // type "h e a r t" it does not match.  in this case the "e" will
+    // cause the sequence to reset
+    //
+    // modifier keys are ignored because you can have a sequence
+    // that contains modifiers such as "enter ctrl+space" and in most
+    // cases the modifier key will be pressed before the next key
+    //
+    // also if you have a sequence such as "ctrl+b a" then pressing the
+    // "b" key will trigger a "keypress" and a "keydown"
+    //
+    // the "keydown" is expected when there is a modifier, but the
+    // "keypress" ends up matching the _nextExpectedAction since it occurs
+    // after and that causes the sequence to reset
+    //
+    // we ignore keypresses in a sequence that directly follow a keydown
+    // for the same character
+    var ignoreThisKeypress = e.type == "keypress" && _ignoreNextKeypress;
+    if (
+      e.type == _nextExpectedAction &&
+      !_isModifier(character) &&
+      !ignoreThisKeypress
+    ) {
+      _resetSequences(doNotReset);
+    }
+
+    _ignoreNextKeypress = processedSequenceCallback && e.type == "keydown";
+  };
+
+  /**
+   * handles a keydown event
+   *
+   * @param {Event} e
+   * @returns void
+   */
+  function _handleKeyEvent(e) {
+    // normalize e.which for key events
+    // @see http://stackoverflow.com/questions/4285627/javascript-keycode-vs-charcode-utter-confusion
+    if (typeof e.which !== "number") {
+      e.which = e.keyCode;
+    }
+
+    var character = _characterFromEvent(e);
+
+    // no character found then stop
+    if (!character) {
+      return;
+    }
+
+    // need to use === for the character check because the character can be 0
+    if (e.type == "keyup" && _ignoreNextKeyup === character) {
+      _ignoreNextKeyup = false;
+      return;
+    }
+
+    self.handleKey(character, _eventModifiers(e), e);
+  }
+
+  /**
+   * called to set a 1 second timeout on the specified sequence
+   *
+   * this is so after each key press in the sequence you have 1 second
+   * to press the next key before you have to start over
+   *
+   * @returns void
+   */
+  function _resetSequenceTimer() {
+    clearTimeout(_resetTimer);
+    _resetTimer = setTimeout(_resetSequences, 1000);
+  }
+
+  /**
+   * binds a key sequence to an event
+   *
+   * @param {string} combo - combo specified in bind call
+   * @param {Array} keys
+   * @param {Function} callback
+   * @param {string=} action
+   * @returns void
+   */
+  function _bindSequence(combo, keys, callback, action) {
+    // start off by adding a sequence level record for this combination
+    // and setting the level to 0
+    _sequenceLevels[combo] = 0;
+
+    /**
+     * callback to increase the sequence level for this sequence and reset
+     * all other sequences that were active
+     *
+     * @param {string} nextAction
+     * @returns {Function}
+     */
+    function _increaseSequence(nextAction) {
+      return function () {
+        _nextExpectedAction = nextAction;
+        ++_sequenceLevels[combo];
+        _resetSequenceTimer();
+      };
+    }
+
+    /**
+     * wraps the specified callback inside of another function in order
+     * to reset all sequence counters as soon as this sequence is done
+     *
+     * @param {Event} e
+     * @returns void
+     */
+    function _callbackAndReset(e) {
+      _fireCallback(callback, e, combo);
+
+      // we should ignore the next key up if the action is key down
+      // or keypress.  this is so if you finish a sequence and
+      // release the key the final key will not trigger a keyup
+      if (action !== "keyup") {
+        _ignoreNextKeyup = _characterFromEvent(e);
+      }
+
+      // weird race condition if a sequence ends with the key
+      // another sequence begins with
+      setTimeout(_resetSequences, 10);
+    }
+
+    // loop through keys one at a time and bind the appropriate callback
+    // function.  for any key leading up to the final one it should
+    // increase the sequence. after the final, it should reset all sequences
+    //
+    // if an action is specified in the original bind call then that will
+    // be used throughout.  otherwise we will pass the action that the
+    // next key in the sequence should match.  this allows a sequence
+    // to mix and match keypress and keydown events depending on which
+    // ones are better suited to the key provided
+    for (var i = 0; i < keys.length; ++i) {
+      var isFinal = i + 1 === keys.length;
+      var wrappedCallback = isFinal
+        ? _callbackAndReset
+        : _increaseSequence(action || _getKeyInfo(keys[i + 1]).action);
+      _bindSingle(keys[i], wrappedCallback, action, combo, i);
+    }
+  }
+
+  /**
+   * binds a single keyboard combination
+   *
+   * @param {string} combination
+   * @param {Function} callback
+   * @param {string=} action
+   * @param {string=} sequenceName - name of sequence if part of sequence
+   * @param {number=} level - what part of the sequence the command is
+   * @returns void
+   */
+  function _bindSingle(combination, callback, action, sequenceName, level) {
+    // store a direct mapped reference for use with Mousetrap.trigger
+    self._directMap[combination + ":" + action] = callback;
+
+    // make sure multiple spaces in a row become a single space
+    combination = combination.replace(/\s+/g, " ");
+
+    var sequence = combination.split(" ");
+    var info;
+
+    // if this pattern is a sequence of keys then run through this method
+    // to reprocess each pattern one key at a time
+    if (sequence.length > 1) {
+      _bindSequence(combination, sequence, callback, action);
+      return;
+    }
+
+    info = _getKeyInfo(combination, action);
+
+    // make sure to initialize array if this is the first time
+    // a callback is added for this key
+    self._callbacks[info.key] = self._callbacks[info.key] || [];
+
+    // remove an existing match if there is one
+    _getMatches(
+      info.key,
+      info.modifiers,
+      { type: info.action },
+      sequenceName,
+      combination,
+      level
+    );
+
+    // add this call back to the array
+    // if it is a sequence put it at the beginning
+    // if not put it at the end
+    //
+    // this is important because the way these are processed expects
+    // the sequence ones to come first
+    self._callbacks[info.key][sequenceName ? "unshift" : "push"]({
+      callback: callback,
+      modifiers: info.modifiers,
+      action: info.action,
+      seq: sequenceName,
+      level: level,
+      combo: combination,
+    });
+  }
+
+  /**
+   * binds multiple combinations to the same callback
+   *
+   * @param {Array} combinations
+   * @param {Function} callback
+   * @param {string|undefined} action
+   * @returns void
+   */
+  self._bindMultiple = function (combinations, callback, action) {
+    for (var i = 0; i < combinations.length; ++i) {
+      _bindSingle(combinations[i], callback, action);
+    }
+  };
+
+  self.enable = function () {
+    _addEvent(targetElement, "keypress", _handleKeyEvent);
+    _addEvent(targetElement, "keydown", _handleKeyEvent);
+    _addEvent(targetElement, "keyup", _handleKeyEvent);
+  };
+
+  self.disable = function () {
+    _removeEvent(targetElement, "keypress", _handleKeyEvent);
+    _removeEvent(targetElement, "keydown", _handleKeyEvent);
+    _removeEvent(targetElement, "keyup", _handleKeyEvent);
+  };
+
+  self.enable();
+}
+
+/**
+ * binds an event to mousetrap
+ *
+ * can be a single key, a combination of keys separated with +,
+ * an array of keys, or a sequence of keys separated by spaces
+ *
+ * be sure to list the modifier keys first to make sure that the
+ * correct key ends up getting bound (the last key in the pattern)
+ *
+ * @param {string|Array} keys
+ * @param {Function} callback
+ * @param {string=} action - 'keypress', 'keydown', or 'keyup'
+ * @returns void
+ */
+Mousetrap.prototype.bind = function (keys, callback, action) {
+  var self = this;
+  keys = keys instanceof Array ? keys : [keys];
+  self._bindMultiple.call(self, keys, callback, action);
+  return self;
+};
+
+/**
+ * unbinds an event to mousetrap
+ *
+ * the unbinding sets the callback function of the specified key combo
+ * to an empty function and deletes the corresponding key in the
+ * _directMap dict.
+ *
+ * TODO: actually remove this from the _callbacks dictionary instead
+ * of binding an empty function
+ *
+ * the keycombo+action has to be exactly the same as
+ * it was defined in the bind method
+ *
+ * @param {string|Array} keys
+ * @param {string} action
+ * @returns void
+ */
+Mousetrap.prototype.unbind = function (keys, action) {
+  var self = this;
+  return self.bind.call(self, keys, function () {}, action);
+};
+
+/**
+ * triggers an event that has already been bound
+ *
+ * @param {string} keys
+ * @param {string=} action
+ * @returns void
+ */
+Mousetrap.prototype.trigger = function (keys, action) {
+  var self = this;
+  if (self._directMap[keys + ":" + action]) {
+    self._directMap[keys + ":" + action]({}, keys);
+  }
+  return self;
+};
+
+/**
+ * resets the library back to its initial state.  this is useful
+ * if you want to clear out the current keyboard shortcuts and bind
+ * new ones - for example if you switch to another page
+ *
+ * @returns void
+ */
+Mousetrap.prototype.reset = function () {
+  var self = this;
+  self._callbacks = {};
+  self._directMap = {};
+  return self;
+};
+
+/**
+ * should we stop this event before firing off callbacks
+ *
+ * @param {Event} e
+ * @param {Element} element
+ * @return {boolean}
+ */
+Mousetrap.prototype.stopCallback = function (e, element) {
+  var self = this;
+
+  // if the element has the class "mousetrap" then no need to stop
+  if ((" " + element.className + " ").indexOf(" mousetrap ") > -1) {
+    return false;
+  }
+
+  if (_belongsTo(element, self.target)) {
+    return false;
+  }
+
+  // stop for input, select, and textarea
+  return (
+    element.tagName == "INPUT" ||
+    element.tagName == "SELECT" ||
+    element.tagName == "TEXTAREA" ||
+    element.isContentEditable
+  );
+};
+
+/**
+ * exposes _handleKey publicly so it can be overwritten by extensions
+ */
+Mousetrap.prototype.handleKey = function () {
+  var self = this;
+  return self._handleKey.apply(self, arguments);
+};
+
+/**
+ * allow custom key mappings
+ */
+Mousetrap.addKeycodes = function (object) {
+  for (var key in object) {
+    if (object.hasOwnProperty(key)) {
+      _MAP[key] = object[key];
+    }
+  }
+  _REVERSE_MAP = null;
+};
+
+/**
+ * Init the global mousetrap functions
+ *
+ * This method is needed to allow the global mousetrap functions to work
+ * now that mousetrap is a constructor function.
+ */
+Mousetrap.init = function () {
+  var documentMousetrap = Mousetrap(document);
+  for (var method in documentMousetrap) {
+    if (method.charAt(0) !== "_") {
+      Mousetrap[method] = (function (method) {
+        return function () {
+          return documentMousetrap[method].apply(documentMousetrap, arguments);
+        };
+      })(method);
+    }
+  }
+};

--- a/src/imba/events/pointer.imba
+++ b/src/imba/events/pointer.imba
@@ -311,8 +311,7 @@ def Event.touch$sync$mod item,xalias='x',yalias='y'
 			ty: state.y
 		}
 	
-	if commit === null
-		commit = yes
+	commit = yes
 
 	item[xalias] = o.x + (state.x - o.tx) if xalias
 	item[yalias] = o.y + (state.y - o.ty) if yalias

--- a/src/imba/imba.imba
+++ b/src/imba/imba.imba
@@ -23,6 +23,7 @@ export * from './events/intersect'
 export * from './events/pointer'
 export * from './events/resize'
 export * from './events/selection'
+export * from './events/hotkey'
 
 # Router
 export * from './router/index'

--- a/src/imba/scheduler.imba
+++ b/src/imba/scheduler.imba
@@ -93,6 +93,10 @@ export class Scheduler
 
 		#schedule! unless #scheduled
 		return self
+	
+	get committing?
+		self.queue.indexOf('commit') >= 0
+
 
 	def listen ns, item
 		let set = listeners[ns]

--- a/src/utils/identifiers.imba
+++ b/src/utils/identifiers.imba
@@ -20,6 +20,7 @@ export const InternalPrefixes = {
 	V: 'υ'
 	K: 'κ'
 	D: 'Δ'
+	H: 'θ'
 }
 
 export const ReservedPrefixes = new Set(Object.values(InternalPrefixes))

--- a/src/utils/spec.imba
+++ b/src/utils/spec.imba
@@ -98,7 +98,7 @@ global class Spec < SpecComponent
 		stack = [context = self]
 		tests = []
 		warnings = []
-		state = {info: [], mutations: [], log: []}
+		state = {info: [], mutations: [], log: [], commits: 0}
 
 		observer = new MutationObserver do(muts)
 			context.state.mutations.push(...muts)
@@ -150,6 +150,8 @@ global class Spec < SpecComponent
 		new Promise do(resolve,reject)
 			pup("spec:start",{})
 			let prevInfo = console.info
+			let fn = do context.state.commits++
+			imba.scheduler.on('commit',fn)
 			observer.observe(document.body,{
 				attributes: true,
 				childList: true,
@@ -164,6 +166,7 @@ global class Spec < SpecComponent
 			imba.once(self,'done') do
 				observer.disconnect!
 				console.info = prevInfo
+				imba.scheduler.un('commit',fn)
 				resolve!
 			await tick!
 			self.step(0)

--- a/test/apps/events/commit.imba
+++ b/test/apps/events/commit.imba
@@ -1,0 +1,52 @@
+###
+By default, Imba will commit (re-render all mounted elements)
+after event-handlers have handled an event. Events can have
+guard-modifiers, that essentially decide whether or not to
+break out of an event handler. If your handler never reaches
+a non-guard modifier or the final callback - it will _not_
+ask Imba to commit afterwards.
+###
+const cb = do yes
+
+# An event handler that never reaches a callback
+# should not commit
+test "not committing" do
+	await imba.commit!
+
+	tag App
+		bool = no
+		<self>
+			<div @click.stop.prevent.log('ok')> "-"
+			<div @click.if(bool)=cb> "-"
+			<div @click.shift.log('ok')=cb> "-"
+			<div @click.silent=cb> "-"
+			<div @click.flag-clicked.silent> "-"
+
+	let app = imba.mount <App>
+	# eq imba.scheduler.committing?, 10
+	for el in app.children
+		# ok imba.scheduler.committing?
+		el.click!
+		ok !imba.scheduler.committing?
+		# eq $1.commits,0
+
+# An event that has no callback will not call event
+test "committing" do
+	await imba.commit!
+
+	tag App
+		bool = yes
+		<self>
+			<div @click.stop=cb> "A"
+			<div @click.if(bool)=cb> "B"
+			# flag will commit by default
+			<div @click.flag-clicked> "C"
+			<div @click.commit> "C"
+
+	let app = imba.mount <App>
+	# eq imba.scheduler.committing?, 10
+	for el in app.children
+		await imba.commit!
+		ok !imba.scheduler.committing?
+		el.click!
+		ok imba.scheduler.committing?

--- a/test/apps/events/hotkey.imba
+++ b/test/apps/events/hotkey.imba
@@ -1,0 +1,100 @@
+import 'imba/test/spec'
+
+const cb = do console.info('cb')
+
+tag App
+	<self>
+		<div$a @hotkey('a').log('a')> "a"
+		
+		# hotkey without a handler will default to a click
+		<div$b @hotkey('b').log('b') @click.log('clicked')=cb> "b"
+		
+		# hotkey without a handler on a form field will default to focus
+		<input$c @hotkey('c').log('c')>
+		
+		# hotkey without a handler on a form field will default to focus
+		<textarea$d @hotkey('d').log('d') @focus.commit>
+		
+		
+		# global hotkeys will trigger even if focus is in textarea or contentEditable
+		<div$x @hotkey('x').capture.log('x')> "x"
+		
+		# you need to set it as passive if you do not want to suppress the native
+		# key event that triggered the hotkey
+		<div$y @hotkey('y').capture.passive.log('y')> "y"
+		
+		# for multiple elements with the same hotkey - the ones later in the dom
+		# will be called first - and always stop there unless they are marked as passive
+		<div @hotkey('f').passive.log('c')> "-"
+		<div @hotkey('f').log('b')> "-"
+		<div @hotkey('f').passive.log('a')> "-"
+
+let app = imba.mount <App>
+let {$a,$b,$x,$y,$c:input,$d:textarea} = app
+
+describe "hotkey" do	
+	test "$a" do
+		await imba.commit!
+		await spec.keyboard.type 'a'
+		eq $1.log,['a']
+		ok !imba.scheduler.committing?
+		
+	test "auto-click" do
+		await imba.commit!
+		await spec.keyboard.type 'b'
+		eq $1.log,['b','clicked','cb']
+		ok imba.scheduler.committing?
+	
+	test "auto-focus" do
+		await imba.commit!
+		await spec.keyboard.type 'c'
+		eq document.activeElement, input
+		ok !imba.scheduler.committing?
+		# the keypress should be prevented
+		eq input.value, ''
+		input.blur!
+		
+		# test with textarea as well
+		await spec.keyboard.type 'd'
+		eq document.activeElement, textarea
+		ok imba.scheduler.committing?
+		eq textarea.value, ''
+		textarea.blur!
+
+	# Don't trigger hotkeys while inside input
+	test "in input" do
+		await imba.commit!
+		await spec.keyboard.type 'c'
+		await spec.keyboard.type 'c'
+		await spec.keyboard.type 'd'
+		eq document.activeElement, input
+		eq input.value, 'cd'
+		eq $1.log, ['c']
+		input.value = ''
+		
+	test "@hotkey.capture" do
+		await imba.commit!
+		input.focus!
+		# the x element has .capture modifier
+		# and will by default capture the hotkey and
+		# prevent the default action even if we are
+		# in an input-field
+		await spec.keyboard.type 'x'
+		eq $1.log, ['x']
+		eq input.value, ''
+		
+		# the y handler has the .passive modifier
+		# so it will not prevent the default (typing y in input)
+		await spec.keyboard.type 'y'
+		eq $1.log, ['x','y']
+		eq input.value, 'y'
+		input.blur!
+	
+	test "@hotkey.passive" do
+		await imba.commit!
+		# the x element has .capture modifier
+		# and will by default capture the hotkey and
+		# prevent the default action even if we are
+		# in an input-field
+		await spec.keyboard.type 'f'
+		eq $1.log, ['a','b']

--- a/test/apps/events/hotkey.imba
+++ b/test/apps/events/hotkey.imba
@@ -32,7 +32,7 @@ describe "hotkey" do
 			<div @hotkey('f').passive.log('a')> "-"
 
 	let app = imba.mount <App>
-	let {$a,$b,$x,$y,$c:input,$d:textarea} = app
+	let {$c:input,$d:textarea} = app
 
 	test "$a" do
 		await imba.commit!
@@ -99,14 +99,24 @@ describe "hotkey" do
 		# in an input-field
 		await spec.keyboard.type 'f'
 		eq $1.log, ['a','b']
+
+describe "multiple hotkeys" do
+	imba.mount do <div>
+		<div @hotkey('a|b|c')=console.info("{e.hotkey}!")> ""
+	
+	test do
+		await spec.keyboard.type 'a'
+		eq $1.log,['a!']
 		
+		await spec.keyboard.type 'b'
+		eq $1.log,['a!','b!']
+
 describe "hotkey dynamic" do
 	let shortcut = 'a'
-	tag App
-		<self> <div @hotkey(shortcut).log('hotkey')> ""
 
-	imba.mount <App>
-	
+	imba.mount do 
+		<div @hotkey(shortcut).log('hotkey')> ""
+
 	test do
 		await spec.keyboard.type 'a'
 		eq $1.log,['hotkey']
@@ -119,5 +129,11 @@ describe "hotkey dynamic" do
 		await spec.keyboard.type 'b'
 		eq $1.log,['hotkey']
 		
-		
-		
+describe "hotkey sequences" do
+	imba.mount do 
+		<div @hotkey('g i').log('yes')> ""
+
+	test do
+		await spec.keyboard.type 'g'
+		await spec.keyboard.type 'i'
+		eq $1.log,['yes']

--- a/test/apps/events/hotkey.imba
+++ b/test/apps/events/hotkey.imba
@@ -2,37 +2,38 @@ import 'imba/test/spec'
 
 const cb = do console.info('cb')
 
-tag App
-	<self>
-		<div$a @hotkey('a').log('a')> "a"
-		
-		# hotkey without a handler will default to a click
-		<div$b @hotkey('b').log('b') @click.log('clicked')=cb> "b"
-		
-		# hotkey without a handler on a form field will default to focus
-		<input$c @hotkey('c').log('c')>
-		
-		# hotkey without a handler on a form field will default to focus
-		<textarea$d @hotkey('d').log('d') @focus.commit>
-		
-		
-		# global hotkeys will trigger even if focus is in textarea or contentEditable
-		<div$x @hotkey('x').capture.log('x')> "x"
-		
-		# you need to set it as passive if you do not want to suppress the native
-		# key event that triggered the hotkey
-		<div$y @hotkey('y').capture.passive.log('y')> "y"
-		
-		# for multiple elements with the same hotkey - the ones later in the dom
-		# will be called first - and always stop there unless they are marked as passive
-		<div @hotkey('f').passive.log('c')> "-"
-		<div @hotkey('f').log('b')> "-"
-		<div @hotkey('f').passive.log('a')> "-"
+describe "hotkey" do
+	
+	tag App
+		<self>
+			<div$a @hotkey('a').log('a')> "a"
+			
+			# hotkey without a handler will default to a click
+			<div$b @hotkey('b').log('b') @click.log('clicked')=cb> "b"
+			
+			# hotkey without a handler on a form field will default to focus
+			<input$c @hotkey('c').log('c')>
+			
+			# hotkey without a handler on a form field will default to focus
+			<textarea$d @hotkey('d').log('d') @focus.commit>
+			
+			
+			# global hotkeys will trigger even if focus is in textarea or contentEditable
+			<div$x @hotkey('x').capture.log('x')> "x"
+			
+			# you need to set it as passive if you do not want to suppress the native
+			# key event that triggered the hotkey
+			<div$y @hotkey('y').capture.passive.log('y')> "y"
+			
+			# for multiple elements with the same hotkey - the ones later in the dom
+			# will be called first - and always stop there unless they are marked as passive
+			<div @hotkey('f').passive.log('c')> "-"
+			<div @hotkey('f').log('b')> "-"
+			<div @hotkey('f').passive.log('a')> "-"
 
-let app = imba.mount <App>
-let {$a,$b,$x,$y,$c:input,$d:textarea} = app
+	let app = imba.mount <App>
+	let {$a,$b,$x,$y,$c:input,$d:textarea} = app
 
-describe "hotkey" do	
 	test "$a" do
 		await imba.commit!
 		await spec.keyboard.type 'a'
@@ -98,3 +99,25 @@ describe "hotkey" do
 		# in an input-field
 		await spec.keyboard.type 'f'
 		eq $1.log, ['a','b']
+		
+describe "hotkey dynamic" do
+	let shortcut = 'a'
+	tag App
+		<self> <div @hotkey(shortcut).log('hotkey')> ""
+
+	imba.mount <App>
+	
+	test do
+		await spec.keyboard.type 'a'
+		eq $1.log,['hotkey']
+		
+	test do
+		shortcut = 'b'
+		await imba.commit!
+		await spec.keyboard.type 'a'
+		eq $1.log,[]
+		await spec.keyboard.type 'b'
+		eq $1.log,['hotkey']
+		
+		
+		

--- a/test/spec.imba
+++ b/test/spec.imba
@@ -201,7 +201,8 @@ global class SpecGroup < SpecComponent
 		parent = parent
 		name = name
 		blocks = []
-		SPEC.eval(blk,self) if blk
+		blk = blk
+		
 		self
 
 	get fullName
@@ -222,6 +223,7 @@ global class SpecGroup < SpecComponent
 	
 	def start
 		emit('start', [self])
+		SPEC.eval(blk,self) if blk
 
 		if console.group
 			console.group(name)
@@ -230,7 +232,15 @@ global class SpecGroup < SpecComponent
 		
 	def finish
 		console.groupEnd(name) if console.groupEnd
+		console.log "ENDED SPEC-GROUP"
+		if parent == SPEC
+			cleanup!
 		emit('done', [self])
+		
+	def cleanup
+		document.body.innerHTML = ''
+		await imba.commit!
+		
 
 global class SpecExample < SpecComponent
 

--- a/test/spec.imba
+++ b/test/spec.imba
@@ -98,7 +98,7 @@ global class Spec < SpecComponent
 		stack = [context = self]
 		tests = []
 		warnings = []
-		state = {info: [], mutations: [], log: []}
+		state = {info: [], mutations: [], log: [],commits: 0}
 
 		observer = new MutationObserver do(muts)
 			context.state.mutations.push(...muts)
@@ -150,6 +150,8 @@ global class Spec < SpecComponent
 		new Promise do(resolve,reject)
 			pup("spec:start",{})
 			let prevInfo = console.info
+			let fn = do context.state.commits++
+			imba.scheduler.on('commit',fn)
 			observer.observe(document.body,{
 				attributes: true,
 				childList: true,
@@ -164,6 +166,7 @@ global class Spec < SpecComponent
 			imba.once(self,'done') do
 				observer.disconnect!
 				console.info = prevInfo
+				imba.scheduler.un('commit',fn)
 				resolve!
 			await tick!
 			self.step(0)
@@ -239,7 +242,7 @@ global class SpecExample < SpecComponent
 		block = block
 		assertions = []
 		root.tests.push(self)
-		state = {info: [], mutations: [], log: []}
+		state = {info: [], mutations: [], log: [], commits: 0}
 		self
 
 	get fullName


### PR DESCRIPTION
Added support for a special `@hotkey` event to support keyboard shortcuts w/o external libraries or techniques. Currently using mousetrap under-the-hood, but we'll likely replace that. The feature will add a few kb to your bundle-size, but only if you use `@hotkey` anywhere in your project.

Checkout the tests in test/apps/events/hotkey.imba for some examples. Examples and docs on imba.io will be added shortly.