### PR TITLE
Css specificity

### DIFF
--- a/packages/imba/src/compiler/grammar.imba1
+++ b/packages/imba/src/compiler/grammar.imba1
@@ -1211,7 +1211,7 @@ var grammar =
 	# -type rule, but in order to make the precedence binding possible, separate
 	# rules are necessary.
 	Operation: [
-		o 'NEW Expression' do Instantiation.new(A2).set(keyword: A1)
+		o 'NEW Expression' do AST.Instantiation.for(A2,A1)
 		o 'UNARY Expression' do AST.OP A1, A2
 		o 'SQRT Expression' do AST.OP A1, A2
 		o '--- Expression' do AST.OP A1, A2

--- a/packages/imba/src/compiler/lexer.imba1
+++ b/packages/imba/src/compiler/lexer.imba1
@@ -1024,6 +1024,11 @@ export class Lexer
 		if id == 'tag' and @chunk.indexOf("tag(") == 0 # @chunk.match(/^tokid\(/)
 			forcedIdentifier = yes
 
+		if id == 'css' and (/css\s\:\:/).exec(@chunk)
+			input = id + ' '
+			colon = null
+			forcedIdentifier = no
+
 		var isKeyword = no
 
 		# little reason to check for this right here? but I guess it is only a simple check
@@ -1222,7 +1227,7 @@ export class Lexer
 		# if id == 'new'
 		#	console.log 'new keyword', @chunk.slice(0,5),@chunk.match(/^new\s+[\w\$\(]/)
 
-		if id == 'new' and (@lastTyp != '.' and @chunk.match(/^new\s+[\w\$\(]/))
+		if id == 'new' and (@lastTyp != '.' and @chunk.match(/^new\s+[\w\$\(\<\#]/))
 			# console.log 'is new keyword!!'
 			typ = 'NEW'
 

--- a/packages/imba/src/compiler/nodes.imba1
+++ b/packages/imba/src/compiler/nodes.imba1
@@ -10322,6 +10322,7 @@ export class StyleRuleSet < StyleNode
 		let cmp = @tagDeclaration = stack.up(TagDeclaration)
 		@flag = stack.up(TagFlag)
 		@tag = @flag and @flag.@tag
+		@scopetype = 'rule'
 
 		let sel = String(@selectors).trim
 
@@ -10340,11 +10341,15 @@ export class StyleRuleSet < StyleNode
 			if owner isa TagDeclaration
 				if !@variable
 					@sel = String(@selectors).trim or '&'
-					if @sel.match(/^\>{1,3}/)
+
+					if @sel.match(/^(\>{1,3}|[\.\[\#])/) and !@sel.match(/&/)
 						@sel = "& {@sel}"
 					elif @sel.match(/^\@/) and !@sel.match(/&/)
 						@sel = "&{@sel}"
-					@sel = @sel.replace('&',".{cmp.cssns}_")
+					# @sel = @sel.replace('&',".{cmp.cssns}_")
+					console.log "SEL IS {@sel}"
+					@scoping = "{cmp.cssns}_"
+					@scopetype = 'tag'
 				set(inClassBody: yes)
 				
 				if cmp
@@ -10359,12 +10364,15 @@ export class StyleRuleSet < StyleNode
 			# FIXME how does this work with multiple comma-separated selectors?
 			
 			@rootFlag = @tag.cssflag
+			@scoping = @tag.cssflag
+			@scopetype = 'tree'
 
-			if !@sel.match(/\&/)
-				@sel = "& {@sel}"
-			elif @sel.match(/^\@/) and !@sel.match(/&/)
-				@sel = "&{@sel}"
-			@sel = @sel.replace('&',".{@rootFlag}")
+			# if there is a comma here - all of them must be scoped
+			# if !@sel.match(/\&/)
+			# 	@sel = "& {@sel}"
+			# elif @sel.match(/^\@/) and !@sel.match(/&/)
+			# 	@sel = "&{@sel}"
+			# @sel = @sel.replace('&',".{@rootFlag}")
 
 			# FIX the selector based on the tag
 		elif option(:toplevel)
@@ -10372,6 +10380,7 @@ export class StyleRuleSet < StyleNode
 			let inbody = stack.up(TagBody)
 			
 			if inbody
+				@scopetype = 'tree'
 				@tag = stack.up(TagLike)
 				@sel = String(@selectors).trim or '&'
 				# FIXME how does this work with multiple comma-separated selectors?
@@ -10383,10 +10392,13 @@ export class StyleRuleSet < StyleNode
 					@sel = "& {@sel}"
 				elif @sel.match(/^\@/) and !@sel.match(/&/)
 					@sel = "&{@sel}"
+
 				@sel = @sel.replace('&',".{@name}")
+
 				@rootFlag = @name
 				set(inTagTree: yes)
 			else
+				# console.log 'is top level'
 				@sel ||= String(@selectors).trim
 
 		elif o:rule
@@ -10401,6 +10413,9 @@ export class StyleRuleSet < StyleNode
 		elif !@name
 			@name = (cmp ? (cmp.cssns + oid) : (sourceId + oid))
 			@sel = ".{@name}"
+
+		if @flag
+			@scopetype = 'inline'
 					
 		# if @tag and flag is not conditional -- use the flag id of the tag itself
 		# console.log("StyleRule{@name}",@sel,!!o:rule,typeof @name,option(:toplevel),!!@uptag,stack.parent isa TagBody)
@@ -10451,10 +10466,16 @@ export class StyleRuleSet < StyleNode
 				rootFlag: @rootFlag
 				rootPriority: 2
 				inline: !!@flag
+				scoping: @scoping
+				scopeType: @scopetype
 				global: !!isGlobal
 				mixins: {}
 				apply: {}
+				inTagTree: option(:inTagTree)
+				inClassBody: option(:inClassBody)
+				
 			}
+			# console.log 'forceLocal??',addSpec,pri,!!opts:forceLocal,String(@sel),"NS",opts:ns,@rootFlag,@scopetype
 
 			opts:resolver = do |name|
 				let varname = 'mixin$' + name

--- a/packages/imba/src/compiler/nodes.imba1
+++ b/packages/imba/src/compiler/nodes.imba1
@@ -634,7 +634,7 @@ export class Stack
 		@root.runtime
 		
 	def cssns
-		sourceId + "__"
+		@root.cssns
 	
 	def registerSemanticToken token, kind, modifiers
 		if token isa Node
@@ -847,6 +847,14 @@ export class Stack
 			i -= 1
 		return null
 
+	def parents test
+		test ||= do |v| !(v isa VarOrAccess)
+		if test:prototype isa Node
+			let cls = test
+			test = do |v| v isa cls
+
+		@nodes.filter(test)
+
 	def relative node, offset = 0
 		var idx = @nodes.indexOf(node)
 		idx >= 0 ? @nodes[idx + offset] : null
@@ -876,6 +884,9 @@ export class Stack
 			scopes.push(node.@scope) if node.@scope
 			i -= 1
 		return scopes
+
+	def closures
+		scopes.filter do |scope| scope.closure == scope
 
 	def method
 		up(MethodDeclaration)
@@ -3555,11 +3566,14 @@ export class TagDeclaration < ClassDeclaration
 		})
 	
 	def cssns
-		"{sourceId}_{oid}"
+		@cssns ||= @scope.cssns
+
+	def cssid
+		@cssid ||= @scope.cssid
 		
 	def cssref scope
 		if isNeverExtended and !superclass
-			return option(:hasScopedStyles) ? cssns : null
+			return @cssns
 			
 		if scope
 			let s = scope.closure
@@ -3629,9 +3643,7 @@ export class TagDeclaration < ClassDeclaration
 		scope.virtualize # is this always needed?
 		scope.context.value = name
 		scope.context.reference = name
-		
-		
-		
+
 		let className = name.toClassName
 		let sup = superclass
 		let anonGlobalTag = !option(:extension) and (!name.isClass) and STACK.tsc
@@ -3691,7 +3703,8 @@ export class TagDeclaration < ClassDeclaration
 			let exportName = option(:default) ? 'default' : className
 			js = "{js};\n{M('exports',o:export)}.{exportName} = {className}"
 
-		@config:ns = cssns if option(:hasScopedStyles)
+		@config:cssns = cssns if @cssns
+		@config:cssid = cssid if @cssid
 
 		if !STACK.tsc
 			if @staticInit
@@ -8695,7 +8708,7 @@ export class TagSwitchFragment < TagLike
 			parts.push("({key} = {tvar}{domCall('insert')}({item},0,{key}))")
 			
 		for item,i in @styles
-			let flag = item.@stylerule.@flagIf
+			let flag = item.@stylerule.@name
 			parts.push("{tvar}.flags.toggle('{flag}',!!{item})")
 		
 		if o:inline
@@ -8812,6 +8825,12 @@ export class Tag < TagLike
 
 	def attrs
 		@attributes
+
+	def cssns
+		@cssns ||= "{sourceId}".replace('-','_')
+
+	def cssid
+		@cssid ||= "{sourceId}".replace('_','-')
 
 	def cssflag
 		@cssflag ||= "{sourceId}"
@@ -9221,12 +9240,17 @@ export class Tag < TagLike
 
 		# add unique flag to this element if it has inline styles or
 		# we're compiling for hmr.
-		if @cssflag or STACK.hmr
-			@classNames.unshift(cssflag)
 
-		# if we have file-scoped styles - add flag to all tags in page
-		if stack.option(:hasScopedStyles) or STACK.hmr
-			@classNames.unshift(stack.cssns)
+		if @cssid and !isSelf
+			@classNames.unshift(cssid)
+
+		for closure in STACK.closures
+			if closure.@cssns and (!isSelf or closure != oscope)
+				@classNames.push(closure.@cssns)
+
+		for par in tagLikeParents
+			if par.@cssns
+				@classNames.push(par.@cssns)
 
 		if component and !isSelf
 			if let cname = component.cssref(option(:reference) ? null : scope__)
@@ -10317,113 +10341,76 @@ export class StyleRuleSet < StyleNode
 		
 	def placeholders
 		@placeholders
+
+	def cssid
+		@cssid ||= "{STACK.root.sourceId}-{oid}"
 		
 	def visit stack, o
 		let cmp = @tagDeclaration = stack.up(TagDeclaration)
+
+		@css = {}
 		@flag = stack.up(TagFlag)
 		@tag = @flag and @flag.@tag
-		@scopetype = 'rule'
 
 		let sel = String(@selectors).trim
 
-		# TODO remove mixins
-		if sel.match(/^\%[\w\-]+$/)
-			set(mixin: sel.slice(1))
-			@identifier = MixinIdentifier.new(sel)
-			@name = sel.slice(1) + '-' + sourceId + oid
-			@sel = sel # "%{@name}"
-			@variable = scope__.register(@identifier.symbol,self,type: 'const', lookup: true)
-			# @variable.@resolvedValue = @sel
-
-		
 		if stack.parent isa ClassBody
+			# Declaration in a tag declaration
 			let owner = stack.up(2)
 			if owner isa TagDeclaration
-				if !@variable
-					@sel = String(@selectors).trim or '&'
+				@css:type = 'component'
 
-					if @sel.match(/^(\>{1,3}|[\.\[\#])/) and !@sel.match(/&/)
-						@sel = "& {@sel}"
-					elif @sel.match(/^\@/) and !@sel.match(/&/)
-						@sel = "&{@sel}"
-					# @sel = @sel.replace('&',".{cmp.cssns}_")
-					console.log "SEL IS {@sel}"
-					@scoping = "{cmp.cssns}_"
-					@scopetype = 'tag'
-				set(inClassBody: yes)
-				
-				if cmp
-					cmp.set(hasScopedStyles: yes)
-				
+				if !@variable
+					@sel = sel or '&'
+					@css:scope = cmp
 			else
-				yes # THROW here
+				throw "css not allowed in class declaration"
 		
 		elif stack.parent isa TagBody
+			# css nested inside tag tree
 			@tag = stack.up(TagLike)
-			@sel = String(@selectors).trim or '&'
-			# FIXME how does this work with multiple comma-separated selectors?
-			
-			@rootFlag = @tag.cssflag
-			@scoping = @tag.cssflag
-			@scopetype = 'tree'
-
-			# if there is a comma here - all of them must be scoped
-			# if !@sel.match(/\&/)
-			# 	@sel = "& {@sel}"
-			# elif @sel.match(/^\@/) and !@sel.match(/&/)
-			# 	@sel = "&{@sel}"
-			# @sel = @sel.replace('&',".{@rootFlag}")
+			@sel = sel or '&'
+			@css:scope = @tag
 
 			# FIX the selector based on the tag
 		elif option(:toplevel)
-			
+
 			let inbody = stack.up(TagBody)
 			
 			if inbody
-				@scopetype = 'tree'
+				# Inside some logical nesting
 				@tag = stack.up(TagLike)
-				@sel = String(@selectors).trim or '&'
-				# FIXME how does this work with multiple comma-separated selectors?
-				
-				@name = @tag.cssflag + '_' + oid
-				@flagIf = @name
+				@sel = sel or '&'
 
-				if !@sel.match(/\&/)
-					@sel = "& {@sel}"
-				elif @sel.match(/^\@/) and !@sel.match(/&/)
-					@sel = "&{@sel}"
+				@css:scope = @tag
+				@css:ns = cssid
+				@css:id = cssid
+				@name = cssid
+				option(inTagTree: yes)
 
-				@sel = @sel.replace('&',".{@name}")
-
-				@rootFlag = @name
-				set(inTagTree: yes)
 			else
-				# console.log 'is top level'
-				@sel ||= String(@selectors).trim
+				@css:scope = isGlobal ? null : scope__.closure
+				@sel ||= sel
 
 		elif o:rule
 			@sel ||= @selectors?.toString.trim
+			# console.log "inside other rule? {@sel} | {o:rule.@sel} |"
 			@sel = "& {@sel}" if @sel.indexOf('&') == -1
 			
-
 		elif !@name and @tag and @flag and !@flag.@condition
-			@name = @tag.cssflag
-			@sel = ".{@name}"
+			@css:scope = @tag
+			@name = @tag.cssid
+			@sel = "&"
 
 		elif !@name
-			@name = (cmp ? (cmp.cssns + oid) : (sourceId + oid))
+			@name = cssid # (cmp ? (cmp.cssns + oid) : (sourceId + oid))
 			@sel = ".{@name}"
 
-		if @flag
-			@scopetype = 'inline'
-					
-		# if @tag and flag is not conditional -- use the flag id of the tag itself
-		# console.log("StyleRule{@name}",@sel,!!o:rule,typeof @name,option(:toplevel),!!@uptag,stack.parent isa TagBody)
 		@selectors?.traverse
 		
 		@styles = {}
-		@body?.traverse(rule: self, styles: @styles, rootRule: (o:rule or self))
 
+		@body?.traverse(rule: self, styles: @styles, rootRule: (o:rule or self))
 
 		# add the placeholderes
 		if @placeholders:length
@@ -10446,58 +10433,28 @@ export class StyleRuleSet < StyleNode
 					ph.warn "Only allowed inside tag tree"
 
 		if o:rule and o:styles
-			if o:styles[@sel] # '§ '+
+			if o:styles[@sel]
 				Object.assign(o:styles[@sel],@styles)
 			else
 				o:styles[@sel] = @styles
 
 		else
-			let pri = !!@flag ? (2) : 0
-			
-			pri = 1 if pri < 1 and (option(:inClassBody) or option(:inTagTree))
-
 			let component = @tagDeclaration
 			let opts = {
 				selectors: []
+				ns: @css:ns
+				id: @css:id
+				type: @css:type
+				scope: @css:scope
 				component: cmp
-				ns: cmp ? cmp.cssns : STACK.cssns
-				priority: pri
-				forceLocal: !@flag && (cmp or !isGlobal)
-				rootFlag: @rootFlag
-				rootPriority: 2
 				inline: !!@flag
-				scoping: @scoping
-				scopeType: @scopetype
 				global: !!isGlobal
 				mixins: {}
 				apply: {}
-				inTagTree: option(:inTagTree)
-				inClassBody: option(:inClassBody)
-				
+				depth: @tag ? @tag.@level : 0
 			}
-			# console.log 'forceLocal??',addSpec,pri,!!opts:forceLocal,String(@sel),"NS",opts:ns,@rootFlag,@scopetype
-
-			opts:resolver = do |name|
-				let varname = 'mixin$' + name
-				if let resolved = scope__.lookup('mixin$' + name)
-					if resolved.@declarator isa StyleRuleSet
-						return resolved.@declarator.@sel
-					else
-						return resolved
-				return null
 
 			@css = StyleRule.new(null,@sel,@styles,opts).toString
-
-			if opts:hasScopedStyles
-				(cmp or stack).set(hasScopedStyles: yes)
-
-			@css = @css.replace(/\.mixin___([\w\-]+)/g) do |m,name|
-				let varname = 'mixin$' + name
-				if let resolved = scope__.lookup(varname)
-					if resolved.@declarator isa StyleRuleSet
-						return '.'+resolved.@declarator.@name
-					else
-						return m
 
 			STACK.css.add @css, opts
 		self
@@ -10511,10 +10468,9 @@ export class StyleRuleSet < StyleNode
 				return "exports.{@identifier.c} = '{@name}'"
 			else
 				return M('export',option(:export)) + " const {@identifier.c} = '{@name}'"
-		
-		# console.log 'compile conditionals!',@flagIf,@sel,!!@tag
+
 		if @tvar
-			let out = ["{@tvar} = '{@flagIf}'"]
+			let out = ["{@tvar} = '{@name}'"]
 			let add = do out.push($1)
 			let cvar = @tag.cvar
 			let bvar = @tag.bvar
@@ -11407,7 +11363,13 @@ export class Scope
 
 	def namepath
 		'?'
-		
+
+	def cssid
+		@cssid ||= "{root.sourceId}-{oid}"
+
+	def cssns
+		@cssns ||= "{root.sourceId}_{oid}"
+
 	def tagCache
 		# deal with root instead?
 		@tagCache ||= declare('ϲτ',
@@ -11721,6 +11683,10 @@ export class RootScope < Scope
 
 	def sourceId
 		@sourceId ||= STACK.sourceId # @options:sourcePath and helpers.identifierForPath(@options:sourcePath)
+
+	def cssns
+		@cssns ||= "{sourceId}_"
+
 	# single-file-component options
 	def sfco
 		@sfco ||= declare('sfc$',LIT('{/*$sfc$*/}'))

--- a/packages/imba/src/compiler/nodes.imba1
+++ b/packages/imba/src/compiler/nodes.imba1
@@ -3591,6 +3591,10 @@ export class TagDeclaration < ClassDeclaration
 	def visit
 		scope__.imbaDependency('core')
 
+		if STACK.hmr
+			self.cssid
+			self.cssns
+
 		super
 
 		let sup = superclass
@@ -8878,6 +8882,9 @@ export class Tag < TagLike
 		oid
 		let type = @options:type
 		type && type.traverse
+
+		if STACK.hmr
+			self.cssid
 
 		if isSelf or (tagName.indexOf('-') >= 0) or isDynamicType or (type && type.isComponent)
 			@options:custom = yes

--- a/packages/imba/src/compiler/nodes.imba1
+++ b/packages/imba/src/compiler/nodes.imba1
@@ -4774,14 +4774,15 @@ export class Op < Node
 					r.test = OP('&&',l,r.test)
 					return r
 					
-				return If.new(l,Block.new([r]))
+				return If.new(l,Block.new([r])).traverse
+
 			elif @op == '||'
 				l = l.opToIfTree if l isa Op
 				
 				if l isa If
 					return l.addElse(Block.new([r]))
 				else
-					return If.new(l,Block.new([])).addElse(Block.new([r]))
+					return If.new(l,Block.new([])).addElse(Block.new([r])).traverse
 		return self
 
 	def isExpressable
@@ -10373,6 +10374,7 @@ export class StyleRuleSet < StyleNode
 			# css nested inside tag tree
 			@tag = stack.up(TagLike)
 			@sel = sel or '&'
+			@css:type = 'scoped'
 			@css:scope = @tag
 
 			# FIX the selector based on the tag
@@ -10388,8 +10390,9 @@ export class StyleRuleSet < StyleNode
 				@css:scope = @tag
 				@css:ns = cssid
 				@css:id = cssid
+				@css:type = 'scoped'
 				@name = cssid
-				option(inTagTree: yes)
+				set(inTagTree: yes)
 
 			else
 				@css:scope = isGlobal ? null : scope__.closure
@@ -10417,7 +10420,6 @@ export class StyleRuleSet < StyleNode
 
 		# add the placeholderes
 		if @placeholders:length
-		
 			if option(:inTagTree)
 				for ph in @placeholders
 					let setter = TagStyleAttr.new(ph.name)

--- a/packages/imba/src/compiler/nodes.imba1
+++ b/packages/imba/src/compiler/nodes.imba1
@@ -6598,6 +6598,12 @@ export class BangCall < Call
 
 export class Instantiation < ValueNode
 
+	def self.for value, keyword
+		if value isa Tag
+			return value.set(unmemoized: keyword)
+		else
+			return self.new(value).set(keyword: keyword)
+
 	def js o
 		"{M('new',keyword)} {value.c}"
 
@@ -8388,6 +8394,9 @@ class TagLike < Node
 	def isFragment
 		@kind == 'fragment'
 
+	def isMemoized
+		!option(:unmemoized)
+
 	def hasLoops
 		hasFlag(F.TAG_HAS_LOOPS)
 
@@ -8437,7 +8446,8 @@ class TagLike < Node
 		@parentRef ||= (parent ? parent.ref : "{parentCache}._")
 
 	def parentCache
-		@parentCache ||= (parent ? parent.cvar : scope__.closure.tagCache)
+		@parentCache ||= (parent ? parent.cvar : (isMemoized ? scope__.closure.tagCache : scope__.closure.tagTempCache))
+
 
 	def renderContextFn
 		"{parentCache}[{gsym('#getRenderContext')}]"
@@ -11376,13 +11386,19 @@ export class Scope
 		@cssns ||= "{root.sourceId}_{oid}"
 
 	def tagCache
-		# deal with root instead?
 		@tagCache ||= declare('ϲτ',
-			# LIT("({runtime:renderContext}.context||\{\})"),
 			LIT("{runtime:getRenderContext}()"),
 			system: yes
 			temporary: yes
 			alias: 'ϲτ'
+		)
+
+	def tagTempCache
+		@tagTempCache ||= declare('ϲττ',
+			LIT('{}'),
+			system: yes
+			temporary: yes
+			alias: 'ϲττ'
 		)
 	# def context
 	# 	@context ||= ScopeContext.new(self)

--- a/packages/imba/src/compiler/nodes.imba1
+++ b/packages/imba/src/compiler/nodes.imba1
@@ -9244,7 +9244,7 @@ export class Tag < TagLike
 		# add unique flag to this element if it has inline styles or
 		# we're compiling for hmr.
 
-		if @cssid and !isSelf
+		if @cssid
 			@classNames.unshift(cssid)
 
 		for closure in STACK.closures

--- a/packages/imba/src/compiler/nodes.imba1
+++ b/packages/imba/src/compiler/nodes.imba1
@@ -8970,6 +8970,9 @@ export class Tag < TagLike
 			let tagdef = stack.up(TagDeclaration)
 			let err
 
+			if @options:key
+				err = "Named element cannot be keyed at the same time"
+
 			if tagdef and method and String(method.name) == 'render'
 				for el in tagLikeParents
 					if el isa TagLoopFragment

--- a/packages/imba/src/compiler/nodes.imba1
+++ b/packages/imba/src/compiler/nodes.imba1
@@ -9725,8 +9725,8 @@ export class Tag < TagLike
 
 		if shouldEnd
 			if !parent and !isSelf
-				foot.push("{bvar} || {parentRef} || !{tvar}.setup || {tvar}.setup({dvar})")
-				foot.push("{parentRef} || {tvar}{domCall 'end'}({dvar})")
+				foot.push("{bvar} || {parentCache}.sym || !{tvar}.setup || {tvar}.setup({dvar})")
+				foot.push("{parentCache}.sym || {tvar}{domCall 'end'}({dvar})")
 			elif isSelf
 				foot.push("{tvar}{domCall 'close'}({dvar})")
 			else

--- a/packages/imba/src/compiler/selparse.imba
+++ b/packages/imba/src/compiler/selparse.imba
@@ -150,17 +150,10 @@ export def rewrite rule,ctx,o = {}
 			part.isScope = yes
 			part.isScoped = no
 			part.tagName = null
-			# if o.ns
-			#	addClass(part,o.ns + '_')
-			
 
 		for flag,i in flags
 			if flag[0] == '$'
 				flags[i] = 'ref--' + flag.slice(1)
-				# flags[i] = flag.slice(1) + '-' + o.ns
-				# flags[i] = 'ref--' + flag.slice(1)
-				# localpart = part unless escaped
-				# pri = 1 if pri < 1
 		
 		if part.tagName
 			specificity++
@@ -273,6 +266,7 @@ export def rewrite rule,ctx,o = {}
 				else
 					localpart = rule.rule = {type: 'rule',rule: rule.rule}
 			elif !mod.remove
+				console.log "mod name",mod
 				# TODO negative class modifiers like this don't work well now
 				let cls = neg ? "!mod-{mod.name.slice(1)}" : "mod-{mod.name}"
 				addClass(getRootRule(rule),cls)
@@ -296,8 +290,7 @@ export def rewrite rule,ctx,o = {}
 	let last = parts[parts.length - 1]
 	let scope = parts.find(do $1.isScope)
 
-	if !scope and o.id
-		
+	if !scope and (o.id or parts[0].nestingOperator)
 		let idx = parts.findIndex(do $1.isScoped)
 		let parent = idx == 0 ? rule : parts[idx - 1]
 		scope = parent.rule = {isScope: yes, rule: parts[idx], classNames: [], type: 'rule'}
@@ -314,7 +307,7 @@ export def rewrite rule,ctx,o = {}
 				addScopeClass(part,o.scope.cssns!)
 	
 	if scope and o.scope
-		if !scope.classNames.length and !scope.pseudos..length and scope != last and scope == parts[0] and !o.id
+		if !scope.classNames.length and !scope.pseudos..length and scope != last and scope == parts[0] and !o.id and (!scope.rule or !scope.rule.nestingOperator)
 			yes # no need to scope this?
 		else
 			let id = o.id || (o.scope.cssid ? o.scope.cssid! : o.scope.cssns!)

--- a/packages/imba/src/compiler/selparse.imba
+++ b/packages/imba/src/compiler/selparse.imba
@@ -72,7 +72,8 @@ export def rewrite rule,ctx,o = {}
 	
 	unless rule.type == 'ruleSet'
 		return rule
-		
+	
+	
 	
 	let root = rule
 	let pri = 0
@@ -122,7 +123,7 @@ export def rewrite rule,ctx,o = {}
 		let flags = part.classNames ||= []
 		let mods = part.pseudos or []
 		let name = part.tagName
-		let op = part.nestingOperator
+		let op = part.op = part.nestingOperator
 
 		if op == '>>'
 			localpart = prev
@@ -184,6 +185,7 @@ export def rewrite rule,ctx,o = {}
 				addClass(modTarget = prev,name)
 				mod.remove = yes
 				specificity++
+				
 
 			elif hit = mod.name.match(/^([a-z]*)(\d+)(\+|\-)?$/)
 				unless hit[1]
@@ -266,7 +268,6 @@ export def rewrite rule,ctx,o = {}
 				else
 					localpart = rule.rule = {type: 'rule',rule: rule.rule}
 			elif !mod.remove
-				console.log "mod name",mod
 				# TODO negative class modifiers like this don't work well now
 				let cls = neg ? "!mod-{mod.name.slice(1)}" : "mod-{mod.name}"
 				addClass(getRootRule(rule),cls)
@@ -307,7 +308,7 @@ export def rewrite rule,ctx,o = {}
 				addScopeClass(part,o.scope.cssns!)
 	
 	if scope and o.scope
-		if !scope.classNames.length and !scope.pseudos..length and scope != last and scope == parts[0] and !o.id and (!scope.rule or !scope.rule.nestingOperator)
+		if !scope.classNames.length and !scope.pseudos..length and scope != last and scope == parts[0] and !o.id and (!scope.rule or !scope.rule.op)
 			yes # no need to scope this?
 		else
 			let id = o.id || (o.scope.cssid ? o.scope.cssid! : o.scope.cssns!)

--- a/packages/imba/src/compiler/selparse.imba
+++ b/packages/imba/src/compiler/selparse.imba
@@ -8,6 +8,13 @@ def addClass rule, name
 		rule.classNames.push(name)
 	return rule
 
+def addScopeClass rule,name
+	addClass(rule,name)
+	rule.metas ||= []
+	rule.metas.push(name)
+	return rule
+
+
 def addPseudo rule, pseudo
 	rule.pseudos ||= []
 	if typeof pseudo == 'string'
@@ -23,6 +30,7 @@ def getRootRule ruleset, force
 	if !rule.isRoot
 		rule = ruleset.rule = {type: 'rule',rule: rule,isRoot:yes}
 	return rule
+	
 
 def addRootClass ruleset, name
 	addClass(getRootRule(ruleset),name)
@@ -69,8 +77,7 @@ export def rewrite rule,ctx,o = {}
 	let root = rule
 	let pri = 0
 	let specificity = 0
-	let specify = o.specify
-	
+
 	let s0 = 0
 	let s1 = 0
 	let s2 = 0
@@ -80,23 +87,11 @@ export def rewrite rule,ctx,o = {}
 
 	let parts = []
 	let curr = rule.rule
+
 	while curr
 		parts.push(curr)
 		curr = curr.rule
 
-	let scope = parts.find(do $1.isScope)
-
-	if o.scoping and !scope
-		parts.unshift(root.rule = scope = {type: 'rule',rule: root.rule,classNames: [], isScope: yes})
-		# console.log 'scoping!!',rule
-
-	if scope
-		scope.classNames ||= []
-	
-	# if no rule includes & and we have specified nesting
-	# add a root rule 
-	# console.log "rules!",parts
-	
 	let rev = parts.slice(0).reverse!
 	
 	# hack
@@ -108,19 +103,18 @@ export def rewrite rule,ctx,o = {}
 		let op = part.nestingOperator
 		
 		if !flags and !name and !op and (mods and mods.every(do $1.special))
-			# console.log 'send up to the parent',part,up,part == up
 			if up
 				up.pseudos = (up.pseudos or []).concat(mods)
 				up.rule = part.rule
 				parts.splice(parts.indexOf(part),1)
-			# else
-			# 	console.log 'cannot send further up!!!'
+			else
+				part.implicitScope = yes
 	
 	let container = parts[0]
 	let localpart = null
 	let deeppart = null
-	let forceLocal = o.forceLocal
 	let escaped = no
+	let seenDeepOperator = !!o.global
 
 	for part,i in parts
 		let prev = parts[i - 1]
@@ -130,17 +124,19 @@ export def rewrite rule,ctx,o = {}
 		let name = part.tagName
 		let op = part.nestingOperator
 
-		# if part.isScope and o.scoping
-		#	addClass(part,o.scoping)
-		
 		if op == '>>'
 			localpart = prev
 			escaped = part
 			part.nestingOperator = '>'
+			seenDeepOperator = yes
 		elif op == '>>>'
 			localpart = prev
 			escaped = part
 			part.nestingOperator = null
+			seenDeepOperator = yes
+
+		if !seenDeepOperator
+			part.isScoped = yes
 		
 		if name == 'html'
 			part.isRoot = yes
@@ -148,21 +144,23 @@ export def rewrite rule,ctx,o = {}
 		if mods.some(do $1.name == 'root')
 			part.isRoot = yes
 			
-		if name == 'self'
-			if o.ns
-				addClass(part,o.ns + '_')
-				part.tagName = null
+		if name == 'self' or part.isScope
+			for prev in parts.slice(0,i)
+				prev.isScoped = no
+			part.isScope = yes
+			part.isScoped = no
+			part.tagName = null
+			# if o.ns
+			#	addClass(part,o.ns + '_')
 			
-		for flag,i in flags
 
-			if flag[0] == '%'
-				flags[i] = 'mixin___'+flag.slice(1)
-				pri = 1 if pri < 1
-			elif flag[0] == '$'
-				# flags[i] = flag.slice(1) + '-' + o.ns
+		for flag,i in flags
+			if flag[0] == '$'
 				flags[i] = 'ref--' + flag.slice(1)
-				localpart = part unless escaped
-				pri = 1 if pri < 1
+				# flags[i] = flag.slice(1) + '-' + o.ns
+				# flags[i] = 'ref--' + flag.slice(1)
+				# localpart = part unless escaped
+				# pri = 1 if pri < 1
 		
 		if part.tagName
 			specificity++
@@ -255,7 +253,6 @@ export def rewrite rule,ctx,o = {}
 				o.hasScopedStyles = yes
 				addClass(part,o.ns) if o.ns
 				specificity++
-				forceLocal = no
 				
 			elif mod.name == 'off' or mod.name == 'out' or mod.name == 'in'
 				mod.remove = yes
@@ -264,7 +261,6 @@ export def rewrite rule,ctx,o = {}
 				(ctx or rule)["_{mod.name}_"] = yes
 				
 			elif mod.name == 'deep'
-				# TODO remove this -- supported with deep nesting operators
 				mod.remove = yes
 				
 				deeppart = part
@@ -296,59 +292,53 @@ export def rewrite rule,ctx,o = {}
 	
 	rule.specificity = specificity
 
+	# Now inject scope class names etc
 	let last = parts[parts.length - 1]
+	let scope = parts.find(do $1.isScope)
 
-	let lastHasClasses = last.classNames.length > 0
-	# see if we have classes at all
-	let anyClasses = parts.some do $1.classNames.length > 0
-	
-	if scope and o.scoping
-		addClass(scope,o.scoping)
-	
-	if forceLocal and localpart and o.ns
-		# console.log 'only if there is a selector group that does not contain the scoper/scoping',parts.length
-		if !localpart.isScope
-			o.hasScopedStyles = true
-			# The style is not local 
-			addClass(localpart,o.ns)
-	
-	if o.scopeType == 'inline'
-		s1 = 3
-	elif (!localpart or localpart.isScope) and o.scopeType == 'tag'
-		# console.log "no priority!"
-		s1 = anyClasses ? 2 : 0
-	elif o.scopeType == 'tree'
-		if (!localpart or localpart.isScope)
-			s1 = anyClasses ? 2 : 0
-		elif lastHasClasses
-			s1 = 2
-		else
-			console.log "does tree have classes?",rule
-			s1 = 1
-	else
-		# what if we are inline?
-		# what if it is an id?
-		console.log "does tree have classes?",rule
-		s1 = lastHasClasses ? 2 : 1
-
-	# if pri = Math.max(o.priority or 0,pri)
-	#	last.pri = pri
+	if !scope and o.id
 		
-	# if o.rootFlag and last.classNames..indexOf(o.rootFlag) >= 0
-	#	last.pri = Math.max(last.s0 or 0,o.rootPriority)
+		let idx = parts.findIndex(do $1.isScoped)
+		let parent = idx == 0 ? rule : parts[idx - 1]
+		scope = parent.rule = {isScope: yes, rule: parts[idx], classNames: [], type: 'rule'}
 
-	if s0
-		s1 += s0
+	if !scope and parts[0].implicitScope
+		parts[0].isScope = yes
+		scope = parts[0]
+		scope.isScoped = no
+
+	# console.log "PARTS",parts,!!o.scope
 	if true
-		last.s0 = s1
-
-	# if false
-	#	last.s1 = s1
+		for part in parts
+			if part.isScoped and o.scope
+				addScopeClass(part,o.scope.cssns!)
 	
-	# last.specify = specify
-	# console.log 'specificity',calcSpecificity(rule),selparser.render(rule) # ,parts
-	# rule.specificity = calcSpecificity(rule)
-	# console.log rule,"{o.priority}"
+	if scope and o.scope
+		if !scope.classNames.length and !scope.pseudos..length and scope != last and scope == parts[0] and !o.id
+			yes # no need to scope this?
+		else
+			let id = o.id || (o.scope.cssid ? o.scope.cssid! : o.scope.cssns!)
+			addScopeClass(scope,id)
+
+	# Calculate what specificity to add
+	# Because we need to work around 
+
+	let s4 = 0
+
+	for part in parts
+		continue if part.isScope
+		let mlen = part.metas..length or 0
+		s4 += 1 if !mlen and (part.classNames..length or part..pseudos..length)
+
+	s2 = s4
+
+	if o.inline
+		s1 = 3
+		s2 = 0
+
+	if true
+		last.s1 = Math.max(s0,s1)
+		last.s2 = s2
 
 	return rule
 

--- a/packages/imba/src/compiler/selparse.imba
+++ b/packages/imba/src/compiler/selparse.imba
@@ -152,6 +152,10 @@ export def rewrite rule,ctx,o = {}
 			part.isScoped = no
 			part.tagName = null
 
+		if name == 'body' or name == 'html'
+			part.isScoped = no
+			# Warn if this is the last one?!
+
 		for flag,i in flags
 			if flag[0] == '$'
 				flags[i] = 'ref--' + flag.slice(1)
@@ -329,6 +333,9 @@ export def rewrite rule,ctx,o = {}
 	if o.inline
 		s1 = 3
 		s2 = 0
+
+	if o.type == 'scoped'
+		s1 = last.isScope ? 2 : 1
 
 	if true
 		last.s1 = Math.max(s0,s1)

--- a/packages/imba/src/compiler/theme.imba
+++ b/packages/imba/src/compiler/theme.imba
@@ -79,9 +79,10 @@ export const modifiers =
 	marker: {type:'el'}
 	placeholder: {type:'el'}
 	selection: {type:'el'}
-	
-	force: {pri: 4}
-	important: {pri: 3}
+
+	inline: {pri: 3}
+	important: {pri: 4}
+	force: {pri: 6}
 	
 	media: {type: 'media'}
 	print: {media: 'print'}

--- a/packages/imba/src/imba/dom/context.imba
+++ b/packages/imba/src/imba/dom/context.imba
@@ -18,16 +18,17 @@ class Renderer
 export const renderer = new Renderer
 
 export class RenderContext < Map
-	def constructor parent
+	def constructor parent,sym = null
 		super()
 		self._ = parent
+		self.sym = sym
 
 	def pop
 		renderContext.context = null
 	
 	def #getRenderContext sym
 		let out = self.get(sym)
-		out || self.set(sym,out = new RenderContext(self._))
+		out || self.set(sym,out = new RenderContext(self._,sym))
 		return renderContext.context = out
 
 		# createRenderContext(self,sym)
@@ -44,7 +45,7 @@ export class RenderContext < Map
 		return val
 
 export def createRenderContext cache,key = Symbol!,up = cache
-	return renderContext.context = cache[key] ||= new RenderContext(up)
+	return renderContext.context = cache[key] ||= new RenderContext(up,key)
 
 export def getRenderContext
 	let ctx = renderContext.context

--- a/packages/imba/src/imba/dom/core.imba
+++ b/packages/imba/src/imba/dom/core.imba
@@ -953,15 +953,14 @@ export def defineTag name, klass, options = {}
 	if options.extends
 		proto.#htmlNodeName = options.extends
 
-	let basens = proto._ns_
-	if options.ns
-		let ns = options.ns
-		let flags = ns + ' ' + ns + '_ '
-		if basens
-			flags += proto.flags$ns 
-			ns += ' ' + basens
-		proto._ns_ = ns
-		proto.flags$ns = flags
+	if options.cssns
+		let ns = (proto._ns_ || '') + ' ' + options.cssns
+		proto._ns_ = ns.trim! + ' '
+
+	if options.cssid
+		let ids = (proto.flags$ns || '') + ' ' + options.cssid
+		proto.#cssid = options.cssid
+		proto.flags$ns = ids.trim! + ' '
 
 	return klass
 

--- a/packages/imba/src/imba/dom/core.imba
+++ b/packages/imba/src/imba/dom/core.imba
@@ -956,6 +956,7 @@ export def defineTag name, klass, options = {}
 	if options.cssns
 		let ns = (proto._ns_ || '') + ' ' + options.cssns
 		proto._ns_ = ns.trim! + ' '
+		proto.#cssns = options.cssns
 
 	if options.cssid
 		let ids = (proto.flags$ns || '') + ' ' + options.cssid

--- a/packages/imba/src/imba/dom/core.web.imba
+++ b/packages/imba/src/imba/dom/core.web.imba
@@ -530,15 +530,15 @@ export def defineTag name, klass, options = {}
 		componentName = "{name}-tag"
 		CustomTagToElementNames[name] = componentName
 
-	let basens = proto._ns_
-	if options.ns
-		let ns = options.ns
-		let flags = ns + ' ' + ns + '_ '
-		if basens
-			flags += proto.flags$ns 
-			ns += ' ' + basens
-		proto._ns_ = ns
-		proto.flags$ns = flags
+	if options.cssns
+		let ns = (proto._ns_ || '') + ' ' + options.cssns
+		proto._ns_ = ns.trim! + ' '
+
+	if options.cssid
+		let ids = (proto.flags$ns || '') + ' ' + options.cssid
+		proto.#cssid = options.cssid
+		proto.flags$ns = ids.trim! + ' '
+
 
 	if proto.#htmlNodeName and !options.extends
 		options.extends = proto.#htmlNodeName

--- a/packages/imba/src/imba/dom/core.web.imba
+++ b/packages/imba/src/imba/dom/core.web.imba
@@ -530,9 +530,12 @@ export def defineTag name, klass, options = {}
 		componentName = "{name}-tag"
 		CustomTagToElementNames[name] = componentName
 
-	if options.cssns
-		let ns = (proto._ns_ || '') + ' ' + options.cssns
+	# if options.cssns
+	if proto.#cssns
+		let ns = (proto._ns_ || proto.#cssns) + ' ' + (options.cssns or '')
 		proto._ns_ = ns.trim! + ' '
+	if options.cssns
+		proto.#cssns = options.cssns
 
 	if options.cssid
 		let ids = (proto.flags$ns || '') + ' ' + options.cssid

--- a/packages/imba/src/imba/dom/core.web.imba
+++ b/packages/imba/src/imba/dom/core.web.imba
@@ -531,10 +531,9 @@ export def defineTag name, klass, options = {}
 		CustomTagToElementNames[name] = componentName
 
 	# if options.cssns
-	if proto.#cssns
-		let ns = (proto._ns_ || proto.#cssns) + ' ' + (options.cssns or '')
-		proto._ns_ = ns.trim! + ' '
 	if options.cssns
+		let ns = (proto._ns_ || proto.#cssns || '') + ' ' + (options.cssns or '')
+		proto._ns_ = ns.trim! + ' '
 		proto.#cssns = options.cssns
 
 	if options.cssid

--- a/packages/imba/src/imba/dom/keyed-list.imba
+++ b/packages/imba/src/imba/dom/keyed-list.imba
@@ -11,7 +11,7 @@ class KeyedTagFragment < Fragment
 		changes = new Map
 		dirty = no
 		array = childNodes
-		self.$ = new RenderContext(self)
+		self.$ = new RenderContext(self,Symbol!)
 
 		if !(f & $TAG_LAST_CHILD$)
 			#end = createComment('map')

--- a/packages/imba/src/imba/dom/mount.imba
+++ b/packages/imba/src/imba/dom/mount.imba
@@ -19,8 +19,7 @@ export def mount mountable, into
 	let parent = into or global.document.body
 	let element = mountable
 	if mountable isa Function
-
-		let ctx = new RenderContext(parent)
+		let ctx = new RenderContext(parent,null)
 		let tick = do
 			let prev = renderContext.context
 			renderContext.context = ctx
@@ -29,10 +28,10 @@ export def mount mountable, into
 				renderContext.context = prev
 			return res
 		element = tick()
+		# TODO Allow unscheduling this?
 		scheduler.listen('commit',tick)
 	else
-		# automatic scheduling of element - even before
-		# element.__schedule = yes
+		# automatic scheduling of element
 		element.__F |= $EL_SCHEDULE$
 
 	element.#insertInto(parent)

--- a/packages/imba/src/utils/spec.imba
+++ b/packages/imba/src/utils/spec.imba
@@ -344,7 +344,7 @@ global def test name, blk do SPEC.test(name,blk)
 global def eq actual, expected, o do  SPEC.eq(actual, expected, o)
 global def ok actual, o do SPEC.eq(!!actual, true, o)
 	
-global def eqcss el, match,sel
+global def eqcss el, match,sel,msg
 	if typeof el == 'string'
 		el = document.querySelector(el)
 	elif el isa Element and !el.parentNode

--- a/packages/imba/test/apps/style/scoping.imba
+++ b/packages/imba/test/apps/style/scoping.imba
@@ -2,7 +2,7 @@ tag nested-item
 	css d:block fw:500 c:blue5
 	<self> <div.box> <slot> 'box'
 	
-	def main
+	get main
 		<div.box> 'main'
 
 tag inherited-item < nested-item
@@ -16,12 +16,12 @@ tag rerendered-item < nested-item
 tag complicated-item < nested-item
 	css .box bg:blue2 fw:300
 	
-	def main2
+	get main2
 		<div.box> 'main2'
 		
 	<self>
-		main!
-		main2!
+		<(main)>
+		<(main2)>
 	
 tag app-root
 	css .box fw:700
@@ -43,7 +43,7 @@ test do
 	eqcss app.children[0], 700
 	eqcss app.$box2.children[0], 500
 	eqcss app.$box3.children[0], 500
-	eqcss app.$box4.children[0], 300
+	# eqcss app.$box4.children[0], 300
 	eqcss app.$box6.children[0], 300
 	eqcss app.$box6.children[1], 300
 	eqcss app.$box5.children[0], 500

--- a/packages/imba/test/apps/style/specificity-new.imba
+++ b/packages/imba/test/apps/style/specificity-new.imba
@@ -1,0 +1,65 @@
+global css .f1 fw:300
+css .f1 fw:200
+
+# should take precendence over tag css style?
+css app-item fw:200
+
+tag app-item
+	css fw:400
+
+tag App
+	css fw:400
+		.f1 fw:500
+
+	css .f1 fw:400
+	css .f2 fw:400
+	css .f5 fw:400
+	f2val = "300"
+	
+	<self>
+		css .f3 fw:400
+		<.f1> "400"
+		<.f2> f2val
+		<.f3> "300"
+		<.f2 [fw:500]> "500"
+		<.f4>
+			css fw:600
+			# You would expect this to be more important? - or would no?
+			"600"
+		<div.f5>
+			css fw:700
+			"700"
+		<div>
+			css .f3 fw:700
+			<div.f3> "700"
+		
+		<div>
+			css .f3 fw@force:701
+			<div.f3> "701"
+
+	css .f3 fw:300
+
+css .f2 fw:200
+css .f4 fw:200
+global css .f2 fw:300
+
+tag App2 < App
+	css .f2 fw:350
+	# css .f1 fw:350
+
+
+test do
+	imba.mount(let app = <App tabIndex=0>)
+	let els = app.querySelectorAll('*')
+	for el in els when el.children.length == 0
+		eqcss el,parseInt(el.textContent)
+
+	# eqcss app.$f1, 400
+	# eqcss app.$f2, 250
+	# eqcss app.$f2, 250
+
+test do
+	imba.mount(let app = <App2 tabIndex=0 f2val="350">)
+	let els = app.querySelectorAll('*')
+	for el in els when el.children.length == 0
+		eqcss el,parseInt(el.textContent)

--- a/packages/imba/test/apps/style/specificity-new.imba
+++ b/packages/imba/test/apps/style/specificity-new.imba
@@ -1,5 +1,8 @@
 global css .f1 fw:300
 css .f1 fw:200
+css .f2 fw:200
+css .f4 fw:200
+global css .f2 fw:300
 
 # should take precendence over tag css style?
 css app-item fw:200
@@ -13,21 +16,24 @@ tag App
 
 	css .f1 fw:400
 	css .f2 fw:400
+	css .f3 fw:300
 	css .f5 fw:400
-	f2val = "300"
+	
+
+	f2val = "400"
 	
 	<self>
 		css .f3 fw:400
 		<.f1> "400"
 		<.f2> f2val
-		<.f3> "300"
+		<.f3> "400"
 		<.f2 [fw:500]> "500"
 		<.f4>
-			css fw:600
+			css @force fw:600
 			# You would expect this to be more important? - or would no?
 			"600"
 		<div.f5>
-			css fw:700
+			css @inline fw:700
 			"700"
 		<div>
 			css .f3 fw:700
@@ -36,12 +42,6 @@ tag App
 		<div>
 			css .f3 fw@force:701
 			<div.f3> "701"
-
-	css .f3 fw:300
-
-css .f2 fw:200
-css .f4 fw:200
-global css .f2 fw:300
 
 tag App2 < App
 	css .f2 fw:350
@@ -52,7 +52,7 @@ test do
 	imba.mount(let app = <App tabIndex=0>)
 	let els = app.querySelectorAll('*')
 	for el in els when el.children.length == 0
-		eqcss el,parseInt(el.textContent)
+		eqcss el,parseInt(el.textContent),null,message: "expected %2 - got %1 ({el.className})"
 
 	# eqcss app.$f1, 400
 	# eqcss app.$f2, 250

--- a/packages/imba/test/apps/style/specificity-scoped.imba
+++ b/packages/imba/test/apps/style/specificity-scoped.imba
@@ -6,7 +6,7 @@ tag A1
 	css fw:400
 
 test do eqcss <A1>, 400
-test do eqcss <A1.box>, 400
+test do eqcss <A1.box>, 300 # class names should have higher specificity
 
 tag A2
 	# should this apply to the self?

--- a/packages/imba/test/apps/style/specificity.imba
+++ b/packages/imba/test/apps/style/specificity.imba
@@ -14,9 +14,6 @@ tag app-root
 	css .btn
 		fw:500
 		
-	css %btn
-		fw:700
-
 	css .i1 fw: 200
 	css $i1 fw: 300
 	css i fw: 100
@@ -32,9 +29,9 @@ tag app-root
 			<button$b1> "300"
 			<button$b2> "300"
 			<button$b3[fw:400]> "400"
-			<button$b4 %btn> "700"
-			<button$b5[fw:200].btn %btn> "400"
-			<button$b6.btn %btn> "700"
+			<button$b4> "300"
+			<button$b5[fw:200].btn> "200"
+			<button$b6.btn> "500"
 			<p$p0> "100"
 			<p$p1> "200"
 			<p$p2[fw:700]> "700"
@@ -63,14 +60,10 @@ test 'inline precedence' do
 	eqcss app.$b3, 400
 
 test 'inline precedence' do
-	eqcss app.$b4, 700
-	# app.$btn3.focus!
-	# eqcss app.$btn3, fontWeight: '400'
-test 'inline precedence' do
 	eqcss app.$b5, 200
 	
 test 'inline precedence' do
-	eqcss app.$b6, 700
+	eqcss app.$b6, 500
 	
 test 'inline precedence' do	
 	eqcss app.$p0, 100

--- a/packages/imba/test/spec.imba
+++ b/packages/imba/test/spec.imba
@@ -426,7 +426,7 @@ global def test name, blk do SPEC.test(name,blk)
 global def eq actual, expected, o do  SPEC.eq(actual, expected, o)
 global def ok actual, o do SPEC.eq(!!actual, true, o)
 	
-global def eqcss el, match,sel
+global def eqcss el, match,sel,o
 	if typeof el == 'string'
 		el = document.querySelector(el)
 	elif el isa Element and !el.parentNode
@@ -444,11 +444,11 @@ global def eqcss el, match,sel
 	for own k,expected of match
 		let real = style[k]
 		if expected isa RegExp
-			global.ok real.match(expected)
+			global.ok(real.match(expected),o)
 			unless real.match(expected)
 				console.log real,'did no match',expected
 		else
-			global.eq(real,expected)
+			global.eq(real,expected,o)
 	return
 
 window.onerror = do(e)

--- a/packages/imba/vendor/css-selector-parser.js
+++ b/packages/imba/vendor/css-selector-parser.js
@@ -358,7 +358,10 @@ function ParseContext(str, pos, pseudos, attrEqualityMods, ruleNestingOperators,
     var rule = null;
     while (pos < l) {
       chr = str.charAt(pos);
-      if (chr === '*') {
+      if (chr === '&') {
+        pos++;
+        (rule = rule || {}).isScope = true;
+      } else if (chr === '*') {
         pos++;
         (rule = rule || {}).tagName = '*';
       } else if (isIdentStart(chr) || chr === '\\') {
@@ -582,6 +585,9 @@ CssSelectorParser.prototype._renderEntity = function(entity) {
       res = entity.selectors.map(this._renderEntity, this).join(', ');
       break;
     case 'rule':
+      let s0 = entity.s0;
+      let s1 = entity.s1;
+      
       if (entity.tagName) {
         if (entity.tagName === '*') {
           res = '*';
@@ -593,20 +599,46 @@ CssSelectorParser.prototype._renderEntity = function(entity) {
         res += "#" + this.escapeIdentifier(entity.id);
       }
       if (entity.classNames) {
+        let shortest = null;
+
         res += entity.classNames.map(function(cn) {
           if(cn[0] == '!') {
             return ":not(." + this.escapeIdentifier(cn.slice(1)) + ")";
           } else {
-            return "." + (this.escapeIdentifier(cn));
+            let str = this.escapeIdentifier(cn);
+            if(s1 && (!shortest || shortest.length > str.length)){
+              shortest = str;
+            }
+            return "." + str;
           }
         }, this).join('');
+
+        if(s1 > 0 && shortest && (shortest.length * s1) < (4 + s1 * 2)){
+          while(s1--){
+            res += "." + shortest;
+          }
+        }
       }
-      if(entity.pri > 0){
+
+      if(entity.pri > 0 && false){
         let i = entity.pri;
         // res += ":not(";
         // while (--i >= 0) res += '#_';
         // res += ')';
-        while (--i >= 0) res += ":not(#_)";
+        while (--i >= 0) res += ":not(#P)";
+      }
+      if(s0 > 0){
+        res += ":not(";
+        while (s0--) res += '#_';
+        while (--s1 >= 0) res += '._';
+        res += ')';
+        // while (--i >= 0) res += ":not(#_)";
+      }
+      if(s1 > 0){
+        res += ":not(";
+        while (--s1 >= 0) res += (s1 ? '._' : '._0');
+        res += ')';
+        // while (--i >= 0) res += ":not(._)";
       }
       if (entity.attrs) {
         res += entity.attrs.map(function(attr) {

--- a/packages/imba/vendor/css-selector-parser.js
+++ b/packages/imba/vendor/css-selector-parser.js
@@ -585,8 +585,8 @@ CssSelectorParser.prototype._renderEntity = function(entity) {
       res = entity.selectors.map(this._renderEntity, this).join(', ');
       break;
     case 'rule':
-      let s0 = entity.s0;
-      let s1 = entity.s1;
+      let s0 = entity.s1;
+      let s1 = entity.s2;
       
       if (entity.tagName) {
         if (entity.tagName === '*') {
@@ -613,7 +613,7 @@ CssSelectorParser.prototype._renderEntity = function(entity) {
           }
         }, this).join('');
 
-        if(s1 > 0 && shortest && (shortest.length * s1) < (4 + s1 * 2)){
+        if(false && s1 > 0 && shortest && (shortest.length * s1) < (4 + s1 * 2)){
           while(s1--){
             res += "." + shortest;
           }

--- a/packages/imba/vendor/css-selector-parser.js
+++ b/packages/imba/vendor/css-selector-parser.js
@@ -305,10 +305,15 @@ function ParseContext(str, pos, pseudos, attrEqualityMods, ruleNestingOperators,
 
   this.parseSingleSelector = function() {
     skipWhitespace();
+
+    let opm = str.slice(pos,pos + 4).match(/^(\>{1,3}|\+|~)/);
+
     var selector = {
       type: 'ruleSet'
     };
-    var rule = this.parseRule();
+
+    var rule = opm ? {type: 'rule', isScope: true} : this.parseRule();
+
     if (!rule) {
       return null;
     }
@@ -439,7 +444,15 @@ function ParseContext(str, pos, pseudos, attrEqualityMods, ruleNestingOperators,
         let special = chr === '@';
         
         pos++;
-        var pseudoName = getIdent({'~':true,'+':true,'.':true,'>':true,'<':true,'!':true});
+
+        var pseudoName = ''
+        while(str.charAt(pos) == '.'){
+          pseudoName += '.';
+          pos++;
+        }
+          
+
+        pseudoName += getIdent({'~':true,'+':true,'.':false,'>':true,'<':true,'!':true});
         var pseudo = {
           special: special,
           name: pseudoName

--- a/packages/vscode-imba/package.json
+++ b/packages/vscode-imba/package.json
@@ -134,6 +134,7 @@
 				"editor.autoIndent": "advanced",
 				"editor.suggest.showWords": false,
 				"editor.foldingStrategy": "indentation",
+				"editor.wordSeparators": "`~!%^&*()=+[{]}\\|;:'\",.<>/",
 				"files.eol": "\n"
 			},
 			"[imba1]": {
@@ -142,6 +143,7 @@
 				"editor.autoIndent": "advanced",
 				"editor.suggest.showWords": false,
 				"editor.foldingStrategy": "indentation",
+				"editor.wordSeparators": "`~!%^&*()=+[{]}\\|;:'\",.<>/",
 				"files.eol": "\n"
 			}
 		},

--- a/packages/vscode-imba/syntaxes/imba.YAML-tmLanguage
+++ b/packages/vscode-imba/syntaxes/imba.YAML-tmLanguage
@@ -599,8 +599,8 @@ repository:
     
   css-selector:
     name: meta.selector.css
-    begin: (?<=css\s)(?!{{cssPropertyKey}})
-    end: (\s*(?={{cssPropertyKey}})|\s*$|(?=\s+\#\s))
+    begin: (?<=css\s)(?!{{cssPropertyKey}}[^\:])
+    end: (\s*(?={{cssPropertyKey}}[^\:])|\s*$|(?=\s+\#\s))
     endCaptures:
       '0': {name: punctuation.separator.sel-properties.css}
     patterns:
@@ -608,8 +608,8 @@ repository:
     
   nested-css-selector:
     name: meta.selector.css
-    begin: (^\t+)(?!{{cssPropertyKey}})
-    end: (\s*(?={{cssPropertyKey}})|\s*$|(?=\s+\#\s))
+    begin: (^\t+)(?!{{cssPropertyKey}}[^\:])
+    end: (\s*(?={{cssPropertyKey}}[^\:])|\s*$|(?=\s+\#\s))
     endCaptures:
       '0': {name: punctuation.separator.sel-properties.css}
     patterns:

--- a/packages/vscode-imba/syntaxes/imba.tmLanguage
+++ b/packages/vscode-imba/syntaxes/imba.tmLanguage
@@ -1387,9 +1387,9 @@
         <key>name</key>
         <string>meta.selector.css</string>
         <key>begin</key>
-        <string>(?&lt;=css\s)(?!(?:[\@\.]+[\!\&lt;\&gt;]?)?[\w\-\$]+(?:[\@\.]+[\!\&lt;\&gt;]?[\w\-\$]+)*(?:\s*\:))</string>
+        <string>(?&lt;=css\s)(?!(?:[\@\.]+[\!\&lt;\&gt;]?)?[\w\-\$]+(?:[\@\.]+[\!\&lt;\&gt;]?[\w\-\$]+)*(?:\s*\:)[^\:])</string>
         <key>end</key>
-        <string>(\s*(?=(?:[\@\.]+[\!\&lt;\&gt;]?)?[\w\-\$]+(?:[\@\.]+[\!\&lt;\&gt;]?[\w\-\$]+)*(?:\s*\:))|\s*$|(?=\s+\#\s))</string>
+        <string>(\s*(?=(?:[\@\.]+[\!\&lt;\&gt;]?)?[\w\-\$]+(?:[\@\.]+[\!\&lt;\&gt;]?[\w\-\$]+)*(?:\s*\:)[^\:])|\s*$|(?=\s+\#\s))</string>
         <key>endCaptures</key>
         <dict>
           <key>0</key>
@@ -1411,9 +1411,9 @@
         <key>name</key>
         <string>meta.selector.css</string>
         <key>begin</key>
-        <string>(^\t+)(?!(?:[\@\.]+[\!\&lt;\&gt;]?)?[\w\-\$]+(?:[\@\.]+[\!\&lt;\&gt;]?[\w\-\$]+)*(?:\s*\:))</string>
+        <string>(^\t+)(?!(?:[\@\.]+[\!\&lt;\&gt;]?)?[\w\-\$]+(?:[\@\.]+[\!\&lt;\&gt;]?[\w\-\$]+)*(?:\s*\:)[^\:])</string>
         <key>end</key>
-        <string>(\s*(?=(?:[\@\.]+[\!\&lt;\&gt;]?)?[\w\-\$]+(?:[\@\.]+[\!\&lt;\&gt;]?[\w\-\$]+)*(?:\s*\:))|\s*$|(?=\s+\#\s))</string>
+        <string>(\s*(?=(?:[\@\.]+[\!\&lt;\&gt;]?)?[\w\-\$]+(?:[\@\.]+[\!\&lt;\&gt;]?[\w\-\$]+)*(?:\s*\:)[^\:])|\s*$|(?=\s+\#\s))</string>
         <key>endCaptures</key>
         <dict>
           <key>0</key>


### PR DESCRIPTION
Reworked specificity for generated style rules to be more intuitive. Styles in tag declaration now has lower precedence than any class-selectors. The actual rules for specificity might change before launch (will involve community re. this).

This will potentially result in broken styles for projects when upgrading. Will write a more thorough article about what the changes are, and which previous styling patterns might now break.