### PR TITLE
Update core.imba with rel='preload' option for styles

### DIFF
--- a/packages/imba/src/imba/dom/core.imba
+++ b/packages/imba/src/imba/dom/core.imba
@@ -797,6 +797,17 @@ export class HTMLStyleElement < HTMLElement
 	get src
 		#src
 
+	set rel value
+		if #rel =? value
+			yes
+		return
+
+	get rel
+		#rel
+
+	get is_preload
+		#rel.match 'preload'
+
 	get outerHTML
 		if HtmlContext and src
 			(HtmlContext.styles||=[]).push(self)
@@ -807,6 +818,12 @@ export class HTMLStyleElement < HTMLElement
 			setAttribute('rel','stylesheet')
 			setAttribute('href',String(src))
 			let out = super
+			if is_preload
+				setAttribute('rel','preload')
+				setAttribute('as','style')
+				let preloadOut = super
+				nodeName = 'style'
+				return "{preloadOut}{out}"
 			nodeName = 'style'
 			return out
 			


### PR DESCRIPTION
I have added an option for a style tag that if you add a rel='preload' in the tag, it now does this
```
<link rel="preload" href="css/styles.css" as="style"> 
<link rel="stylesheet href="css/styles.css">
```
instead of this
```
<link rel="stylesheet href="css/styles.css">
```