### PR TITLE
Do not merge - use our own build of esbuild

### DIFF
--- a/packages/imba/package-lock.json
+++ b/packages/imba/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "imba",
-  "version": "2.0.0-alpha.209",
+  "version": "2.0.0-alpha.210",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "imba",
-      "version": "2.0.0-alpha.202",
+      "version": "2.0.0-alpha.210",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.4.3",
-        "esbuild": "^0.9.7"
+        "esbuild": "npm:esbuild-for-imba@^0.14.4-8.200"
       },
       "bin": {
         "imba": "bin/imba",
@@ -373,12 +373,293 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.9.7.tgz",
-      "integrity": "sha512-VtUf6aQ89VTmMLKrWHYG50uByMF4JQlVysb8dmg6cOgW8JnFCipmz7p+HNBl+RR3LLCuBxFGVauAe2wfnF9bLg==",
+      "name": "esbuild-for-imba",
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-for-imba/-/esbuild-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-csriu2WbG5wMAleDIIqO/1sLs27+ve6uLLevFyroeebZKZx4sqTvhfNFRSNZKNU2QGqSvT4rv9uod7PXx3XExw==",
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "esbuild-android-64-for-imba": "0.14.48.200",
+        "esbuild-android-arm64-for-imba": "0.14.48.200",
+        "esbuild-darwin-64-for-imba": "0.14.48.200",
+        "esbuild-darwin-arm64-for-imba": "0.14.48.200",
+        "esbuild-freebsd-64-for-imba": "0.14.48.200",
+        "esbuild-freebsd-arm64-for-imba": "0.14.48.200",
+        "esbuild-linux-32-for-imba": "0.14.48.200",
+        "esbuild-linux-64-for-imba": "0.14.48.200",
+        "esbuild-linux-arm-for-imba": "0.14.48.200",
+        "esbuild-linux-arm64-for-imba": "0.14.48.200",
+        "esbuild-linux-mips64le-for-imba": "0.14.48.200",
+        "esbuild-linux-ppc64le-for-imba": "0.14.48.200",
+        "esbuild-linux-riscv64-for-imba": "0.14.48.200",
+        "esbuild-linux-s390x-for-imba": "0.14.48.200",
+        "esbuild-netbsd-64-for-imba": "0.14.48.200",
+        "esbuild-openbsd-64-for-imba": "0.14.48.200",
+        "esbuild-sunos-64-for-imba": "0.14.48.200",
+        "esbuild-windows-32": "0.14.48.200",
+        "esbuild-windows-64": "0.14.48.200",
+        "esbuild-windows-arm64": "0.14.48.200"
+      }
+    },
+    "node_modules/esbuild-android-64-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64-for-imba/-/esbuild-android-64-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-urBcwP3jIhGMBDTkB6TfIEN9mvXYG3YW9xdx+HV/A5gTtj2yUXKmuLdr9EhGzPKL14kH6JryGRYWG8zZNkZCZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-android-arm64-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64-for-imba/-/esbuild-android-arm64-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-jmecHAdljkbuQdARZdrM563rxOkcfzWTgBwr9uOUyTK5Kvs85zAJkok/Y9dl8GMagnYh/W6sZMYpsQK6veVsWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-64-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64-for-imba/-/esbuild-darwin-64-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-PZc0Itu2lTL5/GpMaCgE7unKcXte7Va1gkqZiahIW4fkr3oz6C46vaWFE9TULzejR4T+/fZJGOkWKrKqyH1Sug==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-arm64-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64-for-imba/-/esbuild-darwin-arm64-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-8gy8nfSNrJlG2BwvuQmsH4XuFCFKjJynTZtITrWiFb7Zr6kgObU8ob5F+DuEFOyZvcGUjmgkGwmEeu0GmG6qTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-64-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64-for-imba/-/esbuild-freebsd-64-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-e99QcjG+4Is/vFTdj6nmERWWwvY6tZG7BCOsTr9zy4hTW9vqxuIoZxAHnpGrhFTvFYCEQeHrEXGO7PgWdcZglw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-arm64-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64-for-imba/-/esbuild-freebsd-arm64-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-H2XIbhNAIf3SJDogzTQfW7tUJ9y1xD8EwneCD4I8C2XT3HYSKYV8c5oWCTjV/ZYXG5AKlJ8mTlP7BRb/xlULZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-32-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32-for-imba/-/esbuild-linux-32-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-X4z72YdIWFBKJSTrTpZttDN9++laSPCz0KdPkxNLefw9awWOE+xEWdfz90/7OSoOFQtf20QR16qJ285sxfyK3A==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-64-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64-for-imba/-/esbuild-linux-64-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-0MlkdH6Jp6KP7G8hMoQuwN4RglCyyRNNG13yLWkIeeYi8Z32nP3jZZ41GuwW5TKYElGo+xHfbL5LzFGBYY7F/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm-for-imba/-/esbuild-linux-arm-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-HSJnkF6CZF7xGpSs0Lhde+Hz3c4iD2H7QQvahM1FzjaPKjCVQA/NFMC58lNLT0n5onf60fz4WQpV/kNrEB7NHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm64-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64-for-imba/-/esbuild-linux-arm64-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-6qACU9ydN8A349wPuPC9WV/Oxx9/ccr6TDbEyV4KGQGH7JohNxy08vK4JbHyB2YyNGtYRqgHCfta0CLcmLPaQA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-mips64le-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le-for-imba/-/esbuild-linux-mips64le-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-FZCD82Kdk3aKmZyuvb2kI81trOgzQLrQM3ViywDxmT2T4XLOYAAwvHFMq9tLBa/svgdetISk4Wn+qjrocn7j/g==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-ppc64le-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le-for-imba/-/esbuild-linux-ppc64le-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-giayNcn0DKwH0wydGzl9fxLk23kJsfw7JhU/kAi+/iyZpUN5uk4c9IoWtWlKanWK/8HxDKfQyKyVaoG9Sp66cg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-riscv64-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64-for-imba/-/esbuild-linux-riscv64-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-UVqNdEJrmrFL8UfwJGbQZ/p1WDUFQVsr3aOKDeTlf7mGKJ3OIx67mCSaJuy1659yu85ZAHx8bNRrAbxjPlLXDQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-s390x-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x-for-imba/-/esbuild-linux-s390x-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-RdG4d2Z10WXz7SxTubkls1CTpuSI1cXGCEl37AOlEhesSWYCW9sDriDZ5vpkQQLufJ9JhT62D0DlTGt5vsbv/w==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-netbsd-64-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64-for-imba/-/esbuild-netbsd-64-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-27JTltBsPGalkv7XdXCqKKJNWD7tN2V7SMVfFF8hUTcsvO9m3VKFuycPl6H+6h+j9hXC+M29R7n2/PS3tChL4w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-openbsd-64-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64-for-imba/-/esbuild-openbsd-64-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-+jxTYe9H4ca1cC5utLLlDM5voXwJ+jh/1JWoZirQIJUAvYwMnVO5kt11lRLzL+SZNwebeH3d7/bbfPwYe4lQ7g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-sunos-64-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64-for-imba/-/esbuild-sunos-64-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-uLFX+hMjQMfhZdqrgun3U8qkWZyO2EPNnQ3Xi+lhsav8pVBuiHEnt5qZdoBV4fy+3iKiT6r0MDM28+gqYDLTxg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/eventemitter3": {
@@ -1471,9 +1752,133 @@
       }
     },
     "esbuild": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.9.7.tgz",
-      "integrity": "sha512-VtUf6aQ89VTmMLKrWHYG50uByMF4JQlVysb8dmg6cOgW8JnFCipmz7p+HNBl+RR3LLCuBxFGVauAe2wfnF9bLg=="
+      "version": "npm:esbuild-for-imba@0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-for-imba/-/esbuild-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-csriu2WbG5wMAleDIIqO/1sLs27+ve6uLLevFyroeebZKZx4sqTvhfNFRSNZKNU2QGqSvT4rv9uod7PXx3XExw==",
+      "requires": {
+        "esbuild-android-64-for-imba": "0.14.48.200",
+        "esbuild-android-arm64-for-imba": "0.14.48.200",
+        "esbuild-darwin-64-for-imba": "0.14.48.200",
+        "esbuild-darwin-arm64-for-imba": "0.14.48.200",
+        "esbuild-freebsd-64-for-imba": "0.14.48.200",
+        "esbuild-freebsd-arm64-for-imba": "0.14.48.200",
+        "esbuild-linux-32-for-imba": "0.14.48.200",
+        "esbuild-linux-64-for-imba": "0.14.48.200",
+        "esbuild-linux-arm-for-imba": "0.14.48.200",
+        "esbuild-linux-arm64-for-imba": "0.14.48.200",
+        "esbuild-linux-mips64le-for-imba": "0.14.48.200",
+        "esbuild-linux-ppc64le-for-imba": "0.14.48.200",
+        "esbuild-linux-riscv64-for-imba": "0.14.48.200",
+        "esbuild-linux-s390x-for-imba": "0.14.48.200",
+        "esbuild-netbsd-64-for-imba": "0.14.48.200",
+        "esbuild-openbsd-64-for-imba": "0.14.48.200",
+        "esbuild-sunos-64-for-imba": "0.14.48.200",
+        "esbuild-windows-32": "0.14.48.200",
+        "esbuild-windows-64": "0.14.48.200",
+        "esbuild-windows-arm64": "0.14.48.200"
+      }
+    },
+    "esbuild-android-64-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64-for-imba/-/esbuild-android-64-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-urBcwP3jIhGMBDTkB6TfIEN9mvXYG3YW9xdx+HV/A5gTtj2yUXKmuLdr9EhGzPKL14kH6JryGRYWG8zZNkZCZQ==",
+      "optional": true
+    },
+    "esbuild-android-arm64-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64-for-imba/-/esbuild-android-arm64-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-jmecHAdljkbuQdARZdrM563rxOkcfzWTgBwr9uOUyTK5Kvs85zAJkok/Y9dl8GMagnYh/W6sZMYpsQK6veVsWQ==",
+      "optional": true
+    },
+    "esbuild-darwin-64-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64-for-imba/-/esbuild-darwin-64-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-PZc0Itu2lTL5/GpMaCgE7unKcXte7Va1gkqZiahIW4fkr3oz6C46vaWFE9TULzejR4T+/fZJGOkWKrKqyH1Sug==",
+      "optional": true
+    },
+    "esbuild-darwin-arm64-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64-for-imba/-/esbuild-darwin-arm64-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-8gy8nfSNrJlG2BwvuQmsH4XuFCFKjJynTZtITrWiFb7Zr6kgObU8ob5F+DuEFOyZvcGUjmgkGwmEeu0GmG6qTQ==",
+      "optional": true
+    },
+    "esbuild-freebsd-64-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64-for-imba/-/esbuild-freebsd-64-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-e99QcjG+4Is/vFTdj6nmERWWwvY6tZG7BCOsTr9zy4hTW9vqxuIoZxAHnpGrhFTvFYCEQeHrEXGO7PgWdcZglw==",
+      "optional": true
+    },
+    "esbuild-freebsd-arm64-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64-for-imba/-/esbuild-freebsd-arm64-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-H2XIbhNAIf3SJDogzTQfW7tUJ9y1xD8EwneCD4I8C2XT3HYSKYV8c5oWCTjV/ZYXG5AKlJ8mTlP7BRb/xlULZg==",
+      "optional": true
+    },
+    "esbuild-linux-32-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32-for-imba/-/esbuild-linux-32-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-X4z72YdIWFBKJSTrTpZttDN9++laSPCz0KdPkxNLefw9awWOE+xEWdfz90/7OSoOFQtf20QR16qJ285sxfyK3A==",
+      "optional": true
+    },
+    "esbuild-linux-64-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64-for-imba/-/esbuild-linux-64-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-0MlkdH6Jp6KP7G8hMoQuwN4RglCyyRNNG13yLWkIeeYi8Z32nP3jZZ41GuwW5TKYElGo+xHfbL5LzFGBYY7F/Q==",
+      "optional": true
+    },
+    "esbuild-linux-arm-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm-for-imba/-/esbuild-linux-arm-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-HSJnkF6CZF7xGpSs0Lhde+Hz3c4iD2H7QQvahM1FzjaPKjCVQA/NFMC58lNLT0n5onf60fz4WQpV/kNrEB7NHQ==",
+      "optional": true
+    },
+    "esbuild-linux-arm64-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64-for-imba/-/esbuild-linux-arm64-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-6qACU9ydN8A349wPuPC9WV/Oxx9/ccr6TDbEyV4KGQGH7JohNxy08vK4JbHyB2YyNGtYRqgHCfta0CLcmLPaQA==",
+      "optional": true
+    },
+    "esbuild-linux-mips64le-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le-for-imba/-/esbuild-linux-mips64le-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-FZCD82Kdk3aKmZyuvb2kI81trOgzQLrQM3ViywDxmT2T4XLOYAAwvHFMq9tLBa/svgdetISk4Wn+qjrocn7j/g==",
+      "optional": true
+    },
+    "esbuild-linux-ppc64le-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le-for-imba/-/esbuild-linux-ppc64le-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-giayNcn0DKwH0wydGzl9fxLk23kJsfw7JhU/kAi+/iyZpUN5uk4c9IoWtWlKanWK/8HxDKfQyKyVaoG9Sp66cg==",
+      "optional": true
+    },
+    "esbuild-linux-riscv64-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64-for-imba/-/esbuild-linux-riscv64-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-UVqNdEJrmrFL8UfwJGbQZ/p1WDUFQVsr3aOKDeTlf7mGKJ3OIx67mCSaJuy1659yu85ZAHx8bNRrAbxjPlLXDQ==",
+      "optional": true
+    },
+    "esbuild-linux-s390x-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x-for-imba/-/esbuild-linux-s390x-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-RdG4d2Z10WXz7SxTubkls1CTpuSI1cXGCEl37AOlEhesSWYCW9sDriDZ5vpkQQLufJ9JhT62D0DlTGt5vsbv/w==",
+      "optional": true
+    },
+    "esbuild-netbsd-64-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64-for-imba/-/esbuild-netbsd-64-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-27JTltBsPGalkv7XdXCqKKJNWD7tN2V7SMVfFF8hUTcsvO9m3VKFuycPl6H+6h+j9hXC+M29R7n2/PS3tChL4w==",
+      "optional": true
+    },
+    "esbuild-openbsd-64-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64-for-imba/-/esbuild-openbsd-64-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-+jxTYe9H4ca1cC5utLLlDM5voXwJ+jh/1JWoZirQIJUAvYwMnVO5kt11lRLzL+SZNwebeH3d7/bbfPwYe4lQ7g==",
+      "optional": true
+    },
+    "esbuild-sunos-64-for-imba": {
+      "version": "0.14.4-8.200",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64-for-imba/-/esbuild-sunos-64-for-imba-0.14.4-8.200.tgz",
+      "integrity": "sha512-uLFX+hMjQMfhZdqrgun3U8qkWZyO2EPNnQ3Xi+lhsav8pVBuiHEnt5qZdoBV4fy+3iKiT6r0MDM28+gqYDLTxg==",
+      "optional": true
     },
     "eventemitter3": {
       "version": "4.0.7",

--- a/packages/imba/package.json
+++ b/packages/imba/package.json
@@ -121,6 +121,6 @@
   },
   "dependencies": {
     "chokidar": "^3.4.3",
-    "esbuild": "^0.9.7"
+    "esbuild": "npm:esbuild-for-imba@^0.14.4-8.200"
   }
 }


### PR DESCRIPTION
This PR uses a custom build of esbuild with the fix needed for bundling. Here is the branch of esbuild that contains the code that generates the build https://github.com/scrimba/esbuild/tree/custom-build. 

In order to publish a new version
- Edit version.txt with the wanted version number
- Run `make publish-for-imba` to build and publish a new version if we need 
- `make clean` to clean up generated files in order to commit 

This PR will unlock using newer versions of esbuild and consequently some nice features will come to imba.