### PR TITLE
add resolveColors option + only compile once

### DIFF
--- a/packages/e2e-tests/vite-ssr-esm/__tests__/vite-ssr-esm.spec.ts
+++ b/packages/e2e-tests/vite-ssr-esm/__tests__/vite-ssr-esm.spec.ts
@@ -68,7 +68,7 @@ test("css", async () => {
 // });
 
 if (!isBuild) {
-  describe.todo("hmr", () => {
+  describe("hmr", () => {
     const updateApp = editFileAndWaitForHmrComplete.bind(null, "src/main.imba");
     // test('should render additional html', async () => {
     // 	expect(await getEl('#hmr-test')).toBe(null);
@@ -83,12 +83,15 @@ if (!isBuild) {
     // TODO: support HMR for styles
     test("should apply style update", async () => {
       expect(await getColor(`button`)).toBe("green");
+	  const counter = await page.$("button")
+	  counter.click()
       await updateApp((content) => content.replace("c:green", "c:red"));
       await untilMatches(
         () => getColor("button"),
         "red",
         "button has color red",
       );
+	  expect(await page.textContent("button")).toMatch("Hello 2 times");
     });
     // test('should not preserve state of updated props', async () => {
     // 	expect(await getText(`#foo`)).toBe('foo');

--- a/packages/e2e-tests/vite-ssr-esm/src/main.imba
+++ b/packages/e2e-tests/vite-ssr-esm/src/main.imba
@@ -1,3 +1,4 @@
+global css body bgc:cool8
 export default tag App
 	count = 0
 	def mount

--- a/packages/imba/src/compiler/nodes.imba1
+++ b/packages/imba/src/compiler/nodes.imba1
@@ -727,7 +727,7 @@ export class Stack
 		@options:imbaPath
 		
 	def resolveColors
-		@options:styles !== 'extern'
+		@options:styles !== 'extern' or @options:resolveColors
 
 	def config
 		@options:config or {}

--- a/packages/vite-plugin-imba/src/utils/compile.ts
+++ b/packages/vite-plugin-imba/src/utils/compile.ts
@@ -24,6 +24,7 @@ const _createCompileImba = (makeHot?: Function) =>
 			filename,
 			generate: ssr ? 'ssr' : 'dom',
 			format: 'esm',
+			resolveColors: true,
 			sourcePath: filename,
 			sourcemap: options.compilerOptions.sourcemap ?? "inline"
 		};
@@ -70,12 +71,9 @@ const _createCompileImba = (makeHot?: Function) =>
 			  }
 			: compileOptions;
 		finalCompileOptions.config = finalCompileOptions
-		const compiled = compile(finalCode, finalCompileOptions);
 		finalCompileOptions.styles = "extern"
-		// compile the code twice, to get the CSS that includes the theme transformations and js that doesn't include 
-		// styles.register call which adds a style tag to the DOM.
-		const compiled_extern = compile(finalCode, finalCompileOptions);
-		compiled.js = {code: compiled_extern.js}
+		const compiled = compile(finalCode, finalCompileOptions);
+		compiled.js = {code: compiled.js}
 		compiled.css = {code: compiled.css}
 		if (emitCss && compiled.css.code) {
 			// TODO properly update sourcemap?


### PR DESCRIPTION
- Add a `resolveColors` option to the compiler to allow resolving colors even when `styles :"extern"` 
- Compile imba files once 