### PR TITLE
add module template to cli

### DIFF
--- a/packages/imba/bin/imba-create.imba
+++ b/packages/imba/bin/imba-create.imba
@@ -26,6 +26,7 @@ let imbapkg = read-package(imbadir) # JSON.parse(nfs.readFileSync(np.resolve(imb
 const templates = [
 	['Full Stack', 'Full stack app with backend in Express (Imba bundler)', "base-template"]
 	['Jamstack', 'Client only application (Vite bundler)', "vite-template"],
+	['Module', 'Good for reusable components, libraries, and use in non-Imba projects (Vite bundler)', "module-template"],
 	# ['Electron', 'Desktop application using Electron (Node)', "electron-template"],
 	['Desktop', 'Desktop application using Tauri (Vite bundler)', "tauri-template"]
 ].map do([name,hint, urlPart]) {name: name, hint: hint, urlPart: urlPart}


### PR DESCRIPTION
Module template: https://github.com/imba/imba-module-template

Tested and working with React, Vue, and Svelte.

It deserves its own template because:
- Incremental adoption is important, the fact that imba uses actual custom elements is a selling point.
- Several additions needed to be made to `vite.config.js`, `package.json`, and `main.imba`.