### PR TITLE
no .gitignore in Vite template

### DIFF
--- a/packages/imba/templates/vite/_gitignore
+++ b/packages/imba/templates/vite/_gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist


### PR DESCRIPTION
I didn’t noticed and added whole node_modules in initial commit to the repo.