### PR TITLE
Fix and improve docs/metadata on easing typings

### DIFF
--- a/packages/imba/typings/styles.d.ts
+++ b/packages/imba/typings/styles.d.ts
@@ -288,8 +288,8 @@ declare namespace imbacss {
         set(val: Ψnumber): void;
     }
 
-    /** 
-     * Shorthand for setting transform skeq-y() 
+    /** Shorthand for ease-all-duration, function, and delay.
+     * Applies to all properties that support transitions
      * @custom
      * @alias ea
     */
@@ -332,7 +332,9 @@ declare namespace imbacss {
     /** @proxy easeΞallΞfunction */ interface eaf extends easeΞallΞfunction {}
     /** @proxy easeΞallΞdelay */ interface eaw extends easeΞallΞdelay {}
     
-    /** Easing colors (color,background-color,border-color,outline-color,fill,stroke,box-shadow) 
+    /** Shorthand for ease-colors-duration, function, and delay.
+     * Applies to color properties (color,background-color,
+     * border-color,outline-color,fill,stroke,box-shadow) 
      * @alias ec
     */
     interface easeΞcolors extends ease {
@@ -346,8 +348,8 @@ declare namespace imbacss {
     /** @proxy easeΞcolorsΞfunction */ interface ecf extends easeΞcolorsΞfunction {}
     /** @proxy easeΞcolorsΞdelay */ interface ecw extends easeΞcolorsΞdelay {}
 
-    /**
-     * Easing opacity
+    /** Shorthand for ease-opacity-duration, function, and delay
+     * Applies to opacity
      * @alias eo
     */
     interface easeΞopacity extends ease {
@@ -362,9 +364,10 @@ declare namespace imbacss {
     /** @proxy easeΞopacityΞdelay */ interface eow extends easeΞopacityΞdelay {}
 
 
-    /** Easing dimensions
-     * top,left,right,bottom,width,height,max-width,max-height
-     * padding,margin,border-width,stroke-width,transform 
+    /** Shorthand for ease-box-duration, function, and delay.
+     * Applies to dimensions (top,left,right,bottom,width,
+     * height,max-width,max-height,padding,margin,border-width,
+     * stroke-width,transform)
      * @alias eb
      * */
     interface easeΞbox extends ease {
@@ -380,7 +383,11 @@ declare namespace imbacss {
 
 
 
-    /** Shorthand for setting transform easings 
+    /** Shorthand for ease-transform-duration, function, and delay.
+     * Applies to transforms (matrix,matrix3d,perspective,rotate,
+     * rotate3d,rotateX,rotateY,rotateZ,translate,translate3d,
+     * translateX,translateY,translateZ,scale,scale3d,scaleX,
+     * scaleY,scaleZ,skew,skewX,skewY)
      * @alias et
     */
     interface easeΞtransform extends ease {


### PR DESCRIPTION
The documentation for the ea/ease property had an incorrect spelling of skew-y in its description.

<p align="center">
<img src="https://user-images.githubusercontent.com/65634520/217442296-c54e8da9-b7eb-4ad9-8360-9049895d80ee.png" width="400">
<img src="https://user-images.githubusercontent.com/65634520/217442352-d9dfcebb-3fef-4be2-949e-9ae25267410f.png" width="400">
</p>

After some discussion with @familyfriendlymikey over the Discord server, we came up with a solution. This PR not only corrects the spelling error, but also improves the overall readability of both the code and the docs by updating to the metadata/comments/docs for the two-letter easing shorthands (ea, eb, ec, et, and eo), making it easier for developers to understand and utilize these properties.

<p align="center">
<img src="https://user-images.githubusercontent.com/65634520/217443464-9058f34e-dfa3-43c9-9ab8-309a70f97207.png" width="400">
<img src="https://user-images.githubusercontent.com/65634520/217443490-2815b1f8-041d-49cf-bf2a-25cf7d14701b.png" width="400">
</p>

Hope this clears developers' doubts more effectively and brings more Imba apps with cool transitions to life. 🎉
