### PR TITLE
change intersect to only run on web

### DIFF
--- a/packages/imba/src/imba/events/intersect.imba
+++ b/packages/imba/src/imba/events/intersect.imba
@@ -69,6 +69,7 @@ def getIntersectionObserver opts = IntersectionEventDefaults
 
 extend class Element
 	def on$intersect mods,context,handler,o
+		return unless $web$
 		let obs
 		if mods.options
 			let th = []


### PR DESCRIPTION
When I render a component serverside with an intersect event, it causes an error as intersection observer is only available in a browser context. 