### PR TITLE
fix: --web flag should force a vite client build

### DIFF
--- a/packages/imba/bin/imba.imba
+++ b/packages/imba/bin/imba.imba
@@ -318,7 +318,7 @@ def run entry, o, extras
 			const options = {command: "build", mode: "production"}
 			let clientConfig = await getConfigFilePath("client", options)
 
-			if entry.endsWith "html"
+			if entry.endsWith "html" or o.web
 				entry-points = entry
 				await Vite.build({
 					...clientConfig,


### PR DESCRIPTION
In the vite build, the `--web` option is not used to determine whether a client-only build should be done, so an html entry point is required.

I have made a simple patch that should force a client build when the `--web` CLI flag is provided, bringing the functionality closer to the default imba bundler.