### PR TITLE
Fix `imbac` streaming

### DIFF
--- a/packages/imba/bin/imbac
+++ b/packages/imba/bin/imbac
@@ -332,7 +332,8 @@ CLI.prototype.compileFile = function (src){
 	var dstp = src.targetPath && path.relative(process.cwd(),src.targetPath);
 
 	var srcpAbs = path.resolve(srcp);
-	var dstpAbs = path.resolve(dstp);
+	if(dstp)
+		var dstpAbs = path.resolve(dstp);
 
 	if (srcp.indexOf("../") >= 0) {
 		srcp = srcpAbs;


### PR DESCRIPTION
Streaming was broken.

Test `echo "console.log 'HELLO'" | npx imbac -s`.

P.S. I don't know if anything compiles to `bin/imbac`. If so the change would be required in that place.