### PR TITLE
`imbac` is not showing errors

### DIFF
--- a/packages/imba/bin/imbac
+++ b/packages/imba/bin/imbac
@@ -498,6 +498,7 @@ CLI.prototype.finish = function (){
 
 function main(){
 	var o = helpers.parseArgs(process.argv.slice(2),parseOpts);
+	o.raiseErrors = true;
 
 	(o.colors == null) ? (o.colors = true) : o.colors;
 


### PR DESCRIPTION
Fix: `imbac` is not showing errors. It was returning nothing silently on error.