### PR TITLE
fix the same namespaces in every file if using --stdio

### DIFF
--- a/packages/imba/bin/imbac
+++ b/packages/imba/bin/imbac
@@ -63,7 +63,8 @@ Usage: imbac [options] path/to/script.imba
   --styles [format]      Specify how styles should be added: 'extern', 'inline'
   --silent               only print out errors (skip warnings)
   --hmr                  compile for hot-module-reloading
-  --analyze          print out the scopes and variables of your script
+  --analyze              print out the scopes and variables of your script
+  --source-id [id]       set source id which is used in namespaces
 `;
 
 function CLI(options){


### PR DESCRIPTION
Running `cat file | imbac -s` will transpile file properly but css namespaces will be always the same - as there's no `sourcePath`. To fix this we can provide `sourceId` which without any changes becomes a css namespace. After all to have no troubles we need to run `-s` flag always together with `--source-id [id]` flag.

`imbac -s` will work itself after merging #864. Use branch from this pull request for testing.