### PR TITLE
Fixed delete on imba.locals

### DIFF
--- a/packages/imba/src/imba/storage.imba
+++ b/packages/imba/src/imba/storage.imba
@@ -76,9 +76,14 @@ class Storage
 		return item
 
 	def deleteProperty target, name
-		let key = ns + name
-		delete cache[key]
-		return store.removeItem(key)
+		let key = String(ns) + ':' + name
+
+		delete cache.raw[key]
+		delete cache.rich[key]
+
+		store.removeItem(key)
+		
+		return yes
 
 export const locals = new Proxy(fn,new Storage(global.localStorage))
 


### PR DESCRIPTION
I noticed that you couldn't delete properties with:

`delete imba.locals.testLocal`

it would throw this error:
```
Uncaught (in promise) TypeError: 'deleteProperty' on proxy: trap returned falsish for property 'testLocal'
```

The deleteProperty function should return true.

I also specified deleting from cache.raw and cache.rich