### PR TITLE
Allow default bundler configuration of splitting and assetNames

### DIFF
--- a/packages/imba/src/bundler/bundle.imba
+++ b/packages/imba/src/bundler/bundle.imba
@@ -244,7 +244,7 @@ export default class Bundle < Component
 			outdir: program.outdir
 			globalName: o.globalName
 			publicPath: baseurl or '/'
-			assetNames: "{assetsDir}/[name].[hash]"
+			assetNames: o.assetNames or "{assetsDir}/[name].[hash]"
 			chunkNames: "{assetsDir}/chunks/[name].[hash]"
 			entryNames: o.entryNames or "{assetsDir}/[name].[hash]"
 			conditions: ["imba"]

--- a/packages/imba/src/bundler/config.imba
+++ b/packages/imba/src/bundler/config.imba
@@ -4,6 +4,7 @@ const optionTypes = {
 	hashing: 'boolean'
 	minify: 'boolean'
 	target: 'array'
+	splitting: 'boolean'
 }
 
 export const LOADER_SUFFIXES = {


### PR DESCRIPTION
This adds the ability to configure splitting and assetNames in imbaconfig.json