### PR TITLE
experimental feature: container queries

### DIFF
--- a/packages/imba/src/compiler/selparse.imba
+++ b/packages/imba/src/compiler/selparse.imba
@@ -169,7 +169,7 @@ export def rewrite rule,ctx,o = {}
 			let name = mod.pseudo
 			let meta = modifiers[mod.pseudo]
 
-			const container_regex = /^\!?c-([a-zA-Z-_]+)(\d+)$/
+			const container_regex = /^\!?cq-([a-zA-Z-_]*)(\d+)$/
 
 			if const match = name..match container_regex
 				let num = parseInt(match[2])

--- a/packages/imba/src/compiler/selparse.imba
+++ b/packages/imba/src/compiler/selparse.imba
@@ -169,7 +169,7 @@ export def rewrite rule,ctx,o = {}
 			let name = mod.pseudo
 			let meta = modifiers[mod.pseudo]
 
-			const container_regex = /^c-([a-zA-Z-_]+)\!?(\d+)$/
+			const container_regex = /^\!?c-([a-zA-Z-_]+)(\d+)$/
 
 			if const match = name..match container_regex
 				let num = parseInt(match[2])

--- a/packages/imba/src/compiler/selparse.imba
+++ b/packages/imba/src/compiler/selparse.imba
@@ -65,6 +65,7 @@ export def rewrite rule,ctx,o = {}
 
 	rule.meta = {}
 	rule.media = []
+	rule.container = []
 
 	let parts = []
 	let curr = rule.rule
@@ -168,6 +169,14 @@ export def rewrite rule,ctx,o = {}
 			let name = mod.pseudo
 			let meta = modifiers[mod.pseudo]
 
+			const container_regex = /^c-([a-zA-Z-_]+)\!?(\d+)$/
+
+			if const match = name..match container_regex
+				let num = parseInt(match[2])
+				mod.not = !mod.not if name.match(/\!/)
+				const container-name = match[1]
+				mod.container = "{container-name} " + (mod.not ? "(max-width: {num - 1}px)" : "(min-width: {num}px)")
+
 			if name..match(/^\!?\d+$/)
 				let num = parseInt(name.replace(/\!/,''))
 				mod.not = !mod.not if name[0] == '!'
@@ -185,6 +194,13 @@ export def rewrite rule,ctx,o = {}
 						mod.media = meta.medianeg
 				else
 					mod.media = meta.media
+
+			if meta..container
+				if mod.not
+					if meta.containerneg
+						mod.container = meta.containerneg
+				else
+					mod.container = meta.media
 
 			if mod.pseudo == 'media'
 				mod.media = "({mod.value})"
@@ -204,6 +220,9 @@ export def rewrite rule,ctx,o = {}
 
 			if mod.media
 				rule.media.push(mod.media)
+
+			if mod.container
+				rule.container.push(mod.container)
 
 			if name is 'odd' or name is 'even'
 				Object.assign(mod,meta)
@@ -284,6 +303,7 @@ export def render root, content, options = {}
 	for rule in rules
 		let sel = selparser.render(rule)
 		let [base,media = ''] = sel.split(' @media ')
+		let [cbase,container = ''] = sel.split(' @container ')
 		rule.#string = base
 
 		# can we really group them this way?
@@ -291,8 +311,16 @@ export def render root, content, options = {}
 		if media
 			rule.#media = media = '@media ' + media
 
-		if media != group[0]
-			groups.push(group = [media])
+			if media != group[0]
+				groups.push(group = [media])
+
+		elif container
+			rule.#container = container = '@container  ' + container
+
+			if container != group[0]
+				groups.push(group = [container])
+
+			base = cbase
 
 		group.push(base)
 		root.#rules.push(rule)

--- a/packages/imba/vendor/css-selector-parser.js
+++ b/packages/imba/vendor/css-selector-parser.js
@@ -729,7 +729,19 @@ CssSelectorParser.prototype._renderEntity = function(entity,parent) {
         currentEntity = currentEntity.rule;
       }
       let media = entity.media && entity.media.length ? ` @media ${entity.media.join(' and ')}` : ''
-      res = parts.join(' ') + media;
+
+			let container = entity.container && entity.container.length ? ` @container ${entity.container.join(' and ')}` : ''
+
+			let suffix = ''
+			if (media && container){
+				suffix = ` ${container} and ${media}`
+			} else if (media){
+				suffix = media
+			} else if (container){
+				suffix = container
+			}
+
+      res = parts.join(' ') + suffix;
       break;
     case 'selectors':
       res = entity.selectors.map(this._renderEntity, this).join(', ');
@@ -786,7 +798,7 @@ CssSelectorParser.prototype._renderEntity = function(entity,parent) {
 
         // Identify numeric media here?
 
-        if(part.media || part.skip){
+        if(part.media || part.skip || part.container){
           // console.log('media',rootSelector);
           continue;
         }


### PR DESCRIPTION
Syntax is currently: `@c-article230`, `c@c-article!20`

Here is a complete example:
```
tag my-app
	<self>
		<div[w:100px container:article / inline-size]>
			css
				span @c-article39 c:red4 fs:111cqw
			<span[d@300:block]> "I should be red"

imba.mount <my-app>
```

Note that the container query units are available `cqw` is container query width. + `cqh`, `cqi` inline-size and `cqb` for block-size.