### PR TITLE
Fix awkward spaces between badges

### DIFF
--- a/packages/imba/readme.md
+++ b/packages/imba/readme.md
@@ -6,18 +6,10 @@
 </p>
 
 <p align="center">
-	<a target="_blank" href="https://discord.gg/mkcbkRw">
-		<img src="https://img.shields.io/discord/682180555286380545?color=7289DA&label=%23imba&logo=discord&logoColor=white">
-	</a>
-	<a target="_blank" href="https://www.npmjs.com/package/imba">
-		<img src="https://img.shields.io/npm/dm/imba.svg">
-	</a>
-	<a target="_blank" href="http://makeapullrequest.com">
-		<img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg">
-	</a>
-	<a target="_blank" href="https://www.npmjs.com/package/imba">
-		<img src="https://img.shields.io/npm/l/imba.svg">
-	</a>
+	<a target="_blank" href="https://discord.gg/mkcbkRw"><img src="https://img.shields.io/discord/682180555286380545?color=7289DA&label=%23imba&logo=discord&logoColor=white"></a>
+	<a target="_blank" href="https://www.npmjs.com/package/imba"><img src="https://img.shields.io/npm/dm/imba.svg"></a>
+	<a target="_blank" href="http://makeapullrequest.com"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg"></a>
+	<a target="_blank" href="https://www.npmjs.com/package/imba"><img src="https://img.shields.io/npm/l/imba.svg"></a>
 </p>
 
 Imba is a friendly full-stack programming language for the web that


### PR DESCRIPTION
Shorten each badge to 1 line in order to remove awkward hypertext from the spaces between the badges.