### PR TITLE
Restore keyed list render context delete

### DIFF
--- a/packages/imba/src/imba/dom/keyed-list.imba
+++ b/packages/imba/src/imba/dom/keyed-list.imba
@@ -28,7 +28,9 @@ class KeyedTagFragment < Fragment
 		return false if childNodes.length == 0
 		return true
 
-	def push item, idx
+	def push item, idx, key
+		# allow for removing it from the RenderContext later in removeChild
+		item.key = key
 		# on first iteration we can merely run through
 		unless #domFlags & $TAG_INITED$
 
@@ -81,7 +83,7 @@ class KeyedTagFragment < Fragment
 		insertChild(item,index, prevIndex)
 
 	def removeChild item, index
-		# self.map.delete(item)
+		self.$.delete item.key
 		# what if this is a fragment or virtual node?
 		if item.parentNode
 			# log 'removeChild',item,item.parentNode


### PR DESCRIPTION
Solves #892 issue of memory leak

User @me7 provides a test harness and instructions here. https://github.com/me7/jsbench-imba-v2

A minimal test harness is like this:

```imba
tag app
	rows = []
	def gen10k
		rows = for i in [0 .. 10_000]
			{ key: "row-test-{i}", label: "test row {Math.random!.toString!.substring(2, 8)}" }
	def clear
		rows = []
	<self>
		<button @click=gen10k> "generate 10k rows"
		<br>
		<button @click=clear> "clear"
		<hr>
		<table><tbody>
			for { key, label } in rows
				<tr key=key><td> label

imba.mount <app>
```

Repro steps:

```sh
cd /tmp
git clone -b keyed-list-context-delete https://github.com/the-syndrome/imba.git
cd packages/imba
npm install
npm run build
cd /tmp
npx imba create
cd imba-project
# paste above component into ./src/main.imba
npm rm imba
npm install /tmp/imba/packages/imba
npm run dev
```

+ <http://localhost:3000/>
+ Browser dev tools :arrow_right: Memory
+ :black_circle: Take heap snapshot
+ Click "generate 10k rows" button
+ :black_circle: Take heap snapshot
+ :black_circle: Take heap snapshot, again
+ Click "clear" button
+ :black_circle: Take heap snapshot

The result should look like like this with the memory coming down after clear. Previously it would not reduce.

![Screenshot_20241025_063056](https://github.com/user-attachments/assets/d2bd9bcc-acfa-40db-81d7-bd0132af2547)
