### PR TITLE
Fix logger warn level

### DIFF
--- a/packages/imba/src/utils/logger.imba
+++ b/packages/imba/src/utils/logger.imba
@@ -123,7 +123,8 @@ export class Logger
 
 	def debug do write('debug',*arguments)
 	def info do write('info',*arguments)
-	def warn do write('warn',*arguments)
+	# use "warning" to match logLevels and logSymbols
+	def warn do write('warning',*arguments)
 	def error do write('error',*arguments)
 	def success do write('success',*arguments)
 


### PR DESCRIPTION
## Summary
- fix warn method so warnings are output properly

## Testing
- `npm run build` *(fails: Cannot find module 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_b_68532c99075883258f1bdd783809456c