### PR TITLE
copy public files when running imba with --web flag

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -53,7 +53,7 @@ jobs:
         if: failure()
         shell: bash
         run: tar -cvf test-temp.tar  --exclude="node_modules"  temp/
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: test-failure-${{github.run_id}}-${{ matrix.os }}-${{ matrix.node }}

--- a/packages/imba/src/bundler/bundle.imba
+++ b/packages/imba/src/bundler/bundle.imba
@@ -1598,7 +1598,7 @@ export default class Bundle < Component
 				let file = outfs.lookup(asset.fullpath)
 				await file.write(asset.#contents,asset.hash,asset)
 
-			if staticFilesPath and !program.tmpdir and Object.keys(#bundles.web).length > 0
+			if staticFilesPath and !program.tmpdir and (Object.keys(#bundles.web).length > 0 or static?)
 				await copyPublicFiles!
 
 			# is this only really needed for hmr?


### PR DESCRIPTION
This PR fixes an issue with running `imba --web` where it didn't copy the public assets to the build directory.

(It also unblocks running e2e tests due to deprecated actions package)