### PR TITLE
compiler: remove hasDynamicTagName parameter from renderContext.run

### DIFF
--- a/packages/imba/src/compiler/nodes.imba1
+++ b/packages/imba/src/compiler/nodes.imba1
@@ -11222,7 +11222,7 @@ export class Tag < TagLike
 
 				elif key
 					add "{owncvar}={renderContextFn}({key.osym})"
-					let gets = "{owncvar}.run({key.c},{hasDynamicTagName ? 1 : 0})"
+					let gets = "{owncvar}.run({key.c})"
 					add "({bvar}={dvar}=1,{tvar}={gets}) || ({bvar}={dvar}=0,{owncvar}.cache({ctor}))"
 				else
 					let ref = "{parentCache}[{osym}]"


### PR DESCRIPTION
# Bug Report: Key Attribute on Static Tags Causes `afterVisit` Error

## Issue

Using `key` attribute on a static tag (e.g., `<op-timeout key="something">`) causes:

```
Uncaught TypeError: $7372[$afterVisit$133] is not a function
```

## Introducing Commit

[ad8ed87e](https://github.com/imba/imba/commit/ad8ed87e) - "Update context.imba"

Added support for functional tags returning plain strings by modifying [`RenderContext.run()`](https://github.com/imba/imba/blob/ad8ed87e/packages/imba/src/imba/dom/context.imba#L49-L54):

```imba
def run value, flags = 1
    if typeof value == 'string' and flags == 0
        let node = self.text ||= renderContext.createTextNode(value)
        # returns text node instead of calling self.get(value)
    return self.get(value)
```

## Root Cause

In [`src/compiler/nodes.imba1:11225`](https://github.com/imba/imba/blob/ad8ed87e/packages/imba/src/compiler/nodes.imba1#L11225), the `elif key` branch (for **static** tags with keys) incorrectly used:

```imba
let gets = "{owncvar}.run({key.c},{hasDynamicTagName ? 1 : 0})"
```

For static tags: `hasDynamicTagName = false` -> `flags = 0` -> `run("something", 0)` treats the key as a plain string return -> creates text node -> `#afterVisit` called on text node -> **crash**.

## Fix

[`src/compiler/nodes.imba1:11225`](https://github.com/imba/imba/blob/ad8ed87e/packages/imba/src/compiler/nodes.imba1#L11225)

```diff
- let gets = "{owncvar}.run({key.c},{hasDynamicTagName ? 1 : 0})"
+ let gets = "{owncvar}.run({key.c})"
```

Static tags with keys should always use default `flags = 1` (cache lookup), not the string-handling path.
