### PR TITLE
Fix initial undefined dynamic tag setters

### DIFF
--- a/packages/imba/src/compiler/nodes.mjs
+++ b/packages/imba/src/compiler/nodes.mjs
@@ -17636,8 +17636,6 @@ class Tag extends TagLike {
             ((item._value = LIT("" + iref + "=" + vc)), item);
             add(
               "(" +
-                this.bvar() +
-                "&&" +
                 vc +
                 "===" +
                 iref +
@@ -17653,8 +17651,6 @@ class Tag extends TagLike {
                 "=" +
                 val.c(o) +
                 "," +
-                this.bvar() +
-                "&&" +
                 this.vvar() +
                 "===" +
                 iref +
@@ -17762,8 +17758,6 @@ class Tag extends TagLike {
             ((item._value = LIT("" + iref + "=" + vc)), item);
             add(
               "(" +
-                this.bvar() +
-                "&&" +
                 vc +
                 "===" +
                 iref +
@@ -17779,8 +17773,6 @@ class Tag extends TagLike {
                 "=" +
                 val.c(o) +
                 "," +
-                this.bvar() +
-                "&&" +
                 this.vvar() +
                 "===" +
                 iref +

--- a/packages/imba/test/apps/rendering/attributes.imba
+++ b/packages/imba/test/apps/rendering/attributes.imba
@@ -25,3 +25,21 @@ test 'dataset' do
 test 'dataset 2' do
 	let el = <div data-one-more='a'>
 	eq el.dataset.oneMore, 'a'
+
+let optionalSetterCalls = []
+
+extend tag element
+	set optional-tip val,prev
+		optionalSetterCalls.push(val)
+
+test 'dynamic custom setters ignore initial undefined' do
+	optionalSetterCalls = []
+	let item = {}
+	let el = <div optional-tip=item.tip>
+	eq optionalSetterCalls.length, 0
+
+	optionalSetterCalls = []
+	let tipped = {tip: 'hello'}
+	let el2 = <div optional-tip=tipped.tip>
+	eq optionalSetterCalls.length, 1
+	eq optionalSetterCalls[0], 'hello'


### PR DESCRIPTION
Dynamic tag properties should not call custom setters when their first value matches the empty cache. This restores the previous behavior while still assigning defined first values, and adds a rendering regression test for custom setters.