### PR TITLE
Give SVGAnimatedString an indexOf instead of special-casing it in Flags

### DIFF
--- a/packages/imba/src/imba/dom/core.web.imba
+++ b/packages/imba/src/imba/dom/core.web.imba
@@ -438,15 +438,20 @@ export def createElement name, parent, flags, text
 
 	return el
 
+# svg elements expose className as an SVGAnimatedString. Let it answer
+# the string reads flag syncing does on className, against baseVal.
+extend class SVGAnimatedString
+
+	def indexOf ...params
+		baseVal.indexOf(...params)
+
 extend class SVGElement
 
 	get flags
 		unless $flags
 			$flags = new Flags(self)
-			# className is an SVGAnimatedString here, so the classes the element
-			# was created with are read from the attribute instead
 			if flag$ == SVGElement.prototype.flag$
-				flags$ext = getAttribute('class')
+				flags$ext = className.baseVal
 			flagDeopt$()
 		return $flags
 

--- a/packages/imba/src/imba/dom/flags.imba
+++ b/packages/imba/src/imba/dom/flags.imba
@@ -66,7 +66,7 @@ export class Flags
 			syms = #symbols = [sym]
 			vals = #batches = [str or '']
 
-			if statics and #classes.indexOf(statics) == -1
+			if statics and (dom.className or '').indexOf(statics) == -1
 				syms.push(sym)
 				vals.push(statics)
 
@@ -78,7 +78,7 @@ export class Flags
 				syms.push(sym)
 				vals.push(val)
 
-				if statics and #classes.indexOf(statics) == -1
+				if statics and (dom.className or '').indexOf(statics) == -1
 					syms.push(sym)
 					vals.push(statics)
 
@@ -92,14 +92,6 @@ export class Flags
 			#extras = ' ' + vals.join(' ')
 			sync!
 		return
-
-	# svg elements expose className as an SVGAnimatedString and fragments
-	# have no class attribute at all, so fall back to the attribute when
-	# className is not a string, and to no classes when there is no attribute
-	get #classes
-		let cls = dom.className
-		return cls if cls isa 'string'
-		dom.getAttribute ? (dom.getAttribute('class') or '') : ''
 
 	def valueOf
 		string


### PR DESCRIPTION
## Problem

#930 made `Flags.reconcile` look past non-string `className` values through a helper that falls back to the class attribute and guards owners without one (fragments). That puts a type branch into the flag syncing path for one caller, while the reconcile code still reads as if `className` were a string.

## Solution

Sindre's suggestion from the #930 review: teach `SVGAnimatedString` to answer `indexOf` against `baseVal`. The reconcile keeps its plain `(dom.className || '').indexOf(...)` read, svg elements pass it, and fragments keep falling into the empty-string case with no guard. The `SVGElement` flags getter seeds its cached classes from `className.baseVal` for the same reason.

The existing `svg-dynamic-root` and `fragment-dynamic-root` tests cover both paths; the full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
